### PR TITLE
Fix dirty chunk unloading bug

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -28,10 +28,11 @@ function setSectionDirty (pos, value = true) {
   const y = Math.floor(pos.y / 16) * 16
   const z = Math.floor(pos.z / 16) * 16
   const chunk = world.getColumn(x, z)
-  if (chunk && chunk.sections[Math.floor(y / 16)]) {
-    const key = sectionKey(x, y, z)
+  const key = sectionKey(x, y, z)
+  if (!value) {
+    delete dirtySections[key]
+  } else if (chunk && chunk.sections[Math.floor(y / 16)]) {
     dirtySections[key] = value
-    if (!dirtySections[key]) delete dirtySections[key]
   }
 }
 


### PR DESCRIPTION
When a chunk is loaded in to the worker, that chunk and all its neighbors get marked as dirty so the worker threads can start generating mesh geometries. When unloading the chunks, the chunk gets removed from the worker World's object and setSectionDirty is then called to set it to false. This PR fixes an issue where setSectionDirty wouldn't delete a dirty chunk if the chunk was already unloaded. 

Demo - https://gist.github.com/extremeheat/b8724c0b3010af49e1424e633c1c2f9e