### PR TITLE
Fix electron, add resize

### DIFF
--- a/examples/electron/client/localViewer.js
+++ b/examples/electron/client/localViewer.js
@@ -49,6 +49,12 @@ class LocalViewer {
       this.renderer.render(this.viewer.scene, this.viewer.camera)
     }
     animate()
+
+    window.addEventListener('resize', () => {
+      this.viewer.camera.aspect = window.innerWidth / window.innerHeight
+      this.viewer.camera.updateProjectionMatrix()
+      this.renderer.setSize(window.innerWidth, window.innerHeight)
+    })
   }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,6 +36,12 @@ window.addEventListener('pointerdown', (evt) => {
   socket.emit('mouseClick', { origin: ray.origin, direction: ray.direction, button: evt.button })
 })
 
+window.addEventListener('resize', () => {
+  viewer.camera.aspect = window.innerWidth / window.innerHeight
+  viewer.camera.updateProjectionMatrix()
+  renderer.setSize(window.innerWidth, window.innerHeight)
+})
+
 socket.on('version', (version) => {
   viewer.setVersion(version)
 

--- a/viewer/lib/utils.electron.js
+++ b/viewer/lib/utils.electron.js
@@ -1,12 +1,13 @@
 const THREE = require('three')
+const path = require('path')
 
 function loadTexture (texture, cb) {
-  const url = require.resolve('prismarine-viewer/public/' + texture)
+  const url = path.resolve('../../public/' + texture)
   cb(new THREE.TextureLoader().load(url))
 }
 
 function loadJSON (json, cb) {
-  cb(require('prismarine-viewer/public/' + json))
+  cb(require('../../public/' + json))
 }
 
 module.exports = { loadTexture, loadJSON }


### PR DESCRIPTION
`require.resolve` doesnt work with electron, so I reverted to what was before
I added a feature to auto-resize the view when the window is resized, in both mineflayer and electron