### PR TITLE
Improve standalone generation speed

### DIFF
--- a/examples/standalone/index.js
+++ b/examples/standalone/index.js
@@ -26,16 +26,13 @@ getSchematic('smallhouse1.schem', async (data) => {
   const World = require('prismarine-world')(version)
   const Chunk = require('prismarine-chunk')(version)
 
-  const generator = (x, y, z) => {
-    if (y < 60) return 1
-    return 0
-  }
   const chunkGenerator = (chunkX, chunkZ) => {
     const chunk = new Chunk()
-    for (let y = 0; y < 256; y++) {
-      for (let x = 0; x < 16; x++) {
-        for (let z = 0; z < 16; z++) {
-          chunk.setBlockStateId(new Vec3(x, y, z), generator(chunkX * 16 + x, y, chunkZ * 16 + z))
+    const p = new Vec3(0, 0, 0)
+    for (p.y = 59; p.y < 60; p.y++) {
+      for (p.x = 0; p.x < 16; p.x++) {
+        for (p.z = 0; p.z < 16; p.z++) {
+          chunk.setBlockStateId(p, 1)
         }
       }
     }


### PR DESCRIPTION
Avoid generating all empty or all filled sections.