### PR TITLE
Update headless quality

### DIFF
--- a/lib/headless.js
+++ b/lib/headless.js
@@ -14,7 +14,7 @@ const { createCanvas } = safeRequire('node-canvas-webgl/lib')
 
 const { WorldView, Viewer, getBufferFromStream } = require('../viewer')
 
-module.exports = (bot, { viewDistance = 6, output = 'output.mp4', frames = -1, width = 512, height = 512, logFFMPEG = false }) => {
+module.exports = (bot, { viewDistance = 6, output = 'output.mp4', frames = -1, width = 512, height = 512, logFFMPEG = false, jpegOptions }) => {
   const canvas = createCanvas(width, height)
   const renderer = new THREE.WebGLRenderer({ canvas })
   const viewer = new Viewer(renderer)
@@ -86,8 +86,9 @@ module.exports = (bot, { viewDistance = 6, output = 'output.mp4', frames = -1, w
 
     const imageStream = canvas.createJPEGStream({
       bufsize: 4096,
-      quality: 100,
-      progressive: false
+      quality: 1,
+      progressive: false,
+      ...jpegOptions
     })
 
     if (rtmpOutput || ffmpegOutput) {


### PR DESCRIPTION
in version 2.0 of node-canvas, they updated the `quality` parameter of `createJpegStream` to be between [0,1] instead of [0,100].
* https://github.com/Automattic/node-canvas/blob/8707f3d693366a50e60b028404be606042025c51/CHANGELOG.md#200

The current code will switch to the default (0.75) if the option is out of range, which can result in degraded image quality:
https://github.com/Automattic/node-canvas/blob/12e671decd5bce8cca6040643117249d6b15cea7/src/Canvas.cc#L286