### PR TITLE
Added waitForChunksToRender() function

### DIFF
--- a/examples/exporter/screenshot.js
+++ b/examples/exporter/screenshot.js
@@ -9,6 +9,7 @@ global.Worker = require('worker_threads').Worker
 const { createCanvas } = require('node-canvas-webgl/lib')
 const { Schematic } = require('prismarine-schematic')
 const fs = require('fs').promises
+const path = require('path')
 const Vec3 = require('vec3').Vec3
 
 const { Viewer, WorldView, getBufferFromStream } = require('../..').viewer
@@ -24,7 +25,7 @@ const main = async () => {
   const canvas = createCanvas(width, height)
   const renderer = new THREE.WebGLRenderer({ canvas })
   const viewer = new Viewer(renderer)
-  const data = await fs.readFile('../standalone/public/smallhouse1.schem')
+  const data = await fs.readFile('./examples/standalone/public/smallhouse1.schem')
   const schem = await Schematic.read(data, version)
 
   const world = new World(() => new Chunk())
@@ -44,7 +45,7 @@ const main = async () => {
   viewer.camera.lookAt(point)
 
   await worldView.init(center)
-  await new Promise(resolve => setTimeout(resolve, 6000))
+  await viewer.world.waitForChunksToRender()
   renderer.render(viewer.scene, viewer.camera)
 
   const imageStream = canvas.createJPEGStream({
@@ -53,7 +54,9 @@ const main = async () => {
     progressive: false
   })
   const buf = await getBufferFromStream(imageStream)
-  await fs.writeFile('test.jpg', buf)
+  await fs.mkdir('screenshots/', { recursive: true })
+  await fs.writeFile('screenshots/test.jpg', buf)
   console.log('saved')
+  process.exit(0)
 }
 main()

--- a/examples/exporter/screenshot.js
+++ b/examples/exporter/screenshot.js
@@ -25,7 +25,7 @@ const main = async () => {
   const canvas = createCanvas(width, height)
   const renderer = new THREE.WebGLRenderer({ canvas })
   const viewer = new Viewer(renderer)
-  const data = await fs.readFile('./examples/standalone/public/smallhouse1.schem')
+  const data = await fs.readFile(path.join(__dirname, '../standalone/public/smallhouse1.schem'))
   const schem = await Schematic.read(data, version)
 
   const world = new World(() => new Chunk())
@@ -54,8 +54,8 @@ const main = async () => {
     progressive: false
   })
   const buf = await getBufferFromStream(imageStream)
-  await fs.mkdir('screenshots/', { recursive: true })
-  await fs.writeFile('screenshots/test.jpg', buf)
+  await fs.mkdir(path.join(__dirname, 'screenshots/'), { recursive: true })
+  await fs.writeFile(path.join(__dirname, 'screenshots/test.jpg'), buf)
   console.log('saved')
   process.exit(0)
 }

--- a/viewer/README.md
+++ b/viewer/README.md
@@ -82,6 +82,10 @@ it also listen to these events:
 
 Update the world. This need to be called in the animate function, just before the render.
 
+#### waitForChunksToRender ()
+
+Returns a promise that resolve once all sections marked dirty have been rendered by the worker threads. Can be used to wait for chunks to 'appear'.
+
 ### WorldView
 
 WorldView represents the world from a player/camera point of view

--- a/viewer/lib/viewer.js
+++ b/viewer/lib/viewer.js
@@ -98,6 +98,10 @@ class Viewer {
   update () {
     TWEEN.update()
   }
+
+  async waitForChunksToRender () {
+    await this.world.waitForChunksToRender()
+  }
 }
 
 module.exports = { Viewer }

--- a/viewer/lib/worker.js
+++ b/viewer/lib/worker.js
@@ -31,8 +31,11 @@ function setSectionDirty (pos, value = true) {
   const key = sectionKey(x, y, z)
   if (!value) {
     delete dirtySections[key]
+    postMessage({ type: 'sectionFinished', key })
   } else if (chunk && chunk.sections[Math.floor(y / 16)]) {
     dirtySections[key] = value
+  } else {
+    postMessage({ type: 'sectionFinished', key })
   }
 }
 
@@ -74,6 +77,7 @@ setInterval(() => {
       const transferable = [geometry.positions.buffer, geometry.normals.buffer, geometry.colors.buffer, geometry.uvs.buffer]
       postMessage({ type: 'geometry', key, geometry }, transferable)
     }
+    postMessage({ type: 'sectionFinished', key })
   }
   // const time = performance.now() - start
   // console.log(`Processed ${sections.length} sections in ${time} ms (${time / sections.length} ms/section)`)

--- a/viewer/lib/worldrenderer.js
+++ b/viewer/lib/worldrenderer.js
@@ -2,6 +2,7 @@
 const THREE = require('three')
 const Vec3 = require('vec3').Vec3
 const { loadTexture, loadJSON } = globalThis.isElectron ? require('./utils.electron.js') : require('./utils')
+const { EventEmitter } = require('events')
 
 function mod (x, n) {
   return ((x % n) + n) % n
@@ -11,7 +12,8 @@ class WorldRenderer {
   constructor (scene, numWorkers = 4) {
     this.sectionMeshs = {}
     this.scene = scene
-    this.loadedChunks = {}
+    this.sectionsOutstanding = new Set()
+    this.renderUpdateEmitter = new EventEmitter()
 
     this.material = new THREE.MeshLambertMaterial({ vertexColors: true, transparent: true, alphaTest: 0.1 })
 
@@ -28,9 +30,6 @@ class WorldRenderer {
           let mesh = this.sectionMeshs[data.key]
           if (mesh) this.scene.remove(mesh)
 
-          const chunkCoords = data.key.split(',')
-          if (!this.loadedChunks[chunkCoords[0] + ',' + chunkCoords[2]]) return
-
           const geometry = new THREE.BufferGeometry()
           geometry.setAttribute('position', new THREE.BufferAttribute(data.geometry.positions, 3))
           geometry.setAttribute('normal', new THREE.BufferAttribute(data.geometry.normals, 3))
@@ -42,6 +41,9 @@ class WorldRenderer {
           mesh.position.set(data.geometry.sx, data.geometry.sy, data.geometry.sz)
           this.sectionMeshs[data.key] = mesh
           this.scene.add(mesh)
+        } else if (data.type === 'sectionFinished') {
+          this.sectionsOutstanding.delete(data.key)
+          this.renderUpdateEmitter.emit('update')
         }
       }
       if (worker.on) worker.on('message', (data) => { worker.onmessage({ data }) })
@@ -73,7 +75,6 @@ class WorldRenderer {
   }
 
   addColumn (x, z, chunk) {
-    this.loadedChunks[`${x},${z}`] = true
     for (const worker of this.workers) {
       worker.postMessage({ type: 'chunk', x, z, chunk })
     }
@@ -88,7 +89,6 @@ class WorldRenderer {
   }
 
   removeColumn (x, z) {
-    delete this.loadedChunks[`${x},${z}`]
     for (const worker of this.workers) {
       worker.postMessage({ type: 'unloadChunk', x, z })
     }
@@ -119,6 +119,26 @@ class WorldRenderer {
     // is always dispatched to the same worker
     const hash = mod(Math.floor(pos.x / 16) + Math.floor(pos.y / 16) + Math.floor(pos.z / 16), this.workers.length)
     this.workers[hash].postMessage({ type: 'dirty', x: pos.x, y: pos.y, z: pos.z, value })
+    this.sectionsOutstanding.add(`${Math.floor(pos.x / 16) * 16},${Math.floor(pos.y / 16) * 16},${Math.floor(pos.z / 16) * 16}`)
+  }
+
+  // Listen for chunk rendering updates emitted if a worker finished a render and resolve if the number
+  // of sections not rendered are 0
+  waitForChunksToRender () {
+    return new Promise((resolve, reject) => {
+      if (Array.from(this.sectionsOutstanding).length === 0) {
+        resolve()
+        return
+      }
+
+      const updateHandler = () => {
+        if (this.sectionsOutstanding.size === 0) {
+          this.renderUpdateEmitter.removeListener('update', updateHandler)
+          resolve()
+        }
+      }
+      this.renderUpdateEmitter.on('update', updateHandler)
+    })
   }
 }
 


### PR DESCRIPTION
This function resolves when all sections marked as 'dirty' have been rendered by the workers. Useful for taking pictures with prismarine-viewer as soon as all sections have finished rendering.