### PR TITLE
Make logging optional

### DIFF
--- a/lib/mineflayer.js
+++ b/lib/mineflayer.js
@@ -1,7 +1,7 @@
 const EventEmitter = require('events')
 const { WorldView } = require('../viewer')
 
-module.exports = (bot, { viewDistance = 6, firstPerson = false, port = 3000, prefix = '' }) => {
+module.exports = (bot, { viewDistance = 6, firstPerson = false, port = 3000, prefix = '', log = true }) => {
   const express = require('express')
 
   const app = express()
@@ -79,7 +79,7 @@ module.exports = (bot, { viewDistance = 6, firstPerson = false, port = 3000, pre
   })
 
   http.listen(port, () => {
-    console.log(`Prismarine viewer web server running on *:${port}`)
+    if(log) console.log(`Prismarine viewer web server running on *:${port}`)
   })
 
   bot.viewer.close = () => {

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -1,6 +1,6 @@
 const { Vec3 } = require('vec3')
 
-module.exports = ({ version, world, center = new Vec3(0, 0, 0), viewDistance = 4, port = 3000, prefix = '' }) => {
+module.exports = ({ version, world, center = new Vec3(0, 0, 0), viewDistance = 4, port = 3000, prefix = '', log = true }) => {
   const express = require('express')
 
   const app = express()
@@ -45,7 +45,7 @@ module.exports = ({ version, world, center = new Vec3(0, 0, 0), viewDistance = 4
   })
 
   http.listen(port, () => {
-    console.log(`Prismarine viewer web server running on *:${port}`)
+    if(log) console.log(`Prismarine viewer web server running on *:${port}`)
   })
 
   return viewer


### PR DESCRIPTION
This pull request adds the capability to disable the logging at the start by passing `log: false` in the options object when creating the viewer. Useful for when a custom logging system is in place or when an app supports disabling logging.