### PR TITLE
Three dispose

### DIFF
--- a/viewer/lib/dispose.js
+++ b/viewer/lib/dispose.js
@@ -1,0 +1,37 @@
+const THREE = require('three')
+
+function dispose3 (o) {
+  try {
+    if (o && typeof o === 'object') {
+      if (Array.isArray(o)) {
+        o.forEach(dispose3)
+      } else if (o instanceof THREE.Object3D) {
+        dispose3(o.geometry)
+        dispose3(o.material)
+        if (o.parent) {
+          o.parent.remove(o)
+        }
+        dispose3(o.children)
+      } else if (o instanceof THREE.BufferGeometry) {
+        o.dispose()
+      } else if (o instanceof THREE.Material) {
+        o.dispose()
+        dispose3(o.materials)
+        dispose3(o.map)
+        dispose3(o.lightMap)
+        dispose3(o.bumpMap)
+        dispose3(o.normalMap)
+        dispose3(o.specularMap)
+        dispose3(o.envMap)
+      } else if (typeof o.dispose === 'function') {
+        o.dispose()
+      } else {
+        Object.values(o).forEach(dispose3)
+      }
+    }
+  } catch (error) {
+    console.log(error)
+  }
+}
+
+module.exports = { dispose3 }

--- a/viewer/lib/entities.js
+++ b/viewer/lib/entities.js
@@ -2,6 +2,7 @@ const THREE = require('three')
 const TWEEN = require('@tweenjs/tween.js')
 
 const Entity = require('./entity/Entity')
+const { dispose3 } = require('./dispose')
 
 function getEntityMesh (entity, scene) {
   if (entity.name) {
@@ -52,8 +53,7 @@ class Entities {
   clear () {
     for (const mesh of Object.values(this.entities)) {
       this.scene.remove(mesh)
-      if (mesh.geometry) mesh.geometry.dispose()
-      if (mesh.material) mesh.material.dispose()
+      dispose3(mesh)
     }
     this.entities = {}
   }
@@ -70,8 +70,7 @@ class Entities {
 
     if (entity.delete) {
       this.scene.remove(e)
-      if (e.geometry) e.geometry.dispose()
-      if (e.material) e.material.dispose()
+      dispose3(e)
       delete this.entities[entity.id]
     }
 

--- a/viewer/lib/primitives.js
+++ b/viewer/lib/primitives.js
@@ -1,5 +1,6 @@
 const THREE = require('three')
 const { MeshLine, MeshLineMaterial } = require('three.meshline')
+const { dispose3 } = require('./dispose')
 
 function getMesh (primitive, camera) {
   if (primitive.type === 'line') {
@@ -56,8 +57,7 @@ class Primitives {
   clear () {
     for (const mesh of Object.values(this.primitives)) {
       this.scene.remove(mesh)
-      mesh.geometry.dispose()
-      mesh.material.dispose()
+      dispose3(mesh)
     }
     this.primitives = {}
   }
@@ -65,8 +65,7 @@ class Primitives {
   update (primitive) {
     if (this.primitives[primitive.id]) {
       this.scene.remove(this.primitives[primitive.id])
-      this.primitives[primitive.id].geometry.dispose()
-      this.primitives[primitive.id].material.dispose()
+      dispose3(this.primitives[primitive.id])
       delete this.primitives[primitive.id]
     }
 

--- a/viewer/lib/worldrenderer.js
+++ b/viewer/lib/worldrenderer.js
@@ -3,6 +3,7 @@ const THREE = require('three')
 const Vec3 = require('vec3').Vec3
 const { loadTexture, loadJSON } = globalThis.isElectron ? require('./utils.electron.js') : require('./utils')
 const { EventEmitter } = require('events')
+const { dispose3 } = require('./dispose')
 
 function mod (x, n) {
   return ((x % n) + n) % n
@@ -31,7 +32,8 @@ class WorldRenderer {
           let mesh = this.sectionMeshs[data.key]
           if (mesh) {
             this.scene.remove(mesh)
-            mesh.geometry.dispose()
+            dispose3(mesh)
+            delete this.sectionMeshs[data.key]
           }
 
           const chunkCoords = data.key.split(',')
@@ -107,8 +109,9 @@ class WorldRenderer {
       const mesh = this.sectionMeshs[key]
       if (mesh) {
         this.scene.remove(mesh)
-        mesh.geometry.dispose()
+        dispose3(mesh)
       }
+      delete this.sectionMeshs[key]
     }
   }
 


### PR DESCRIPTION
Incomplete disposal of three objects was causing them to build up in system/JSArrayBuffer on Chrome resulting in increasing memory allocation to prismarine-viewer and ultimately causing the prismarine-web-client page to crash.

This fix implements a belt-and-braces approach to clearing out threejs objects when they are no longer needed.