### PR TITLE
Remove prefix in url of get socket.io

### DIFF
--- a/lib/mineflayer.js
+++ b/lib/mineflayer.js
@@ -7,7 +7,7 @@ module.exports = (bot, { viewDistance = 6, firstPerson = false, port = 3000, pre
   const app = express()
   const http = require('http').createServer(app)
 
-  const io = require('socket.io')(http, { path: prefix + '/socket.io' })
+  const io = require('socket.io')(http, { path: '/socket.io' })
 
   const { setupRoutes } = require('./common')
   setupRoutes(app, prefix)


### PR DESCRIPTION
The correct URL is just (site url)/socket.io. Placing the prefix caused error 404.