### PR TITLE
Fix redstone_wire rendering

### DIFF
--- a/viewer/lib/models.js
+++ b/viewer/lib/models.js
@@ -466,11 +466,11 @@ function matchProperties (block, properties) {
 
   properties = parseProperties(properties)
   const blockProps = block.getProperties()
-  if (properties["OR"]) {
-    return properties["OR"].some((or) => matchProperties(block, or))
+  if (properties.OR) {
+    return properties.OR.some((or) => matchProperties(block, or))
   }
   for (const prop in blockProps) {
-    if (properties[prop] !== undefined && !properties[prop].split("|").some((value) => value == (blockProps[prop] + ''))) {
+    if (properties[prop] !== undefined && !properties[prop].split('|').some((value) => value === (blockProps[prop] + ''))) {
       return false
     }
   }

--- a/viewer/lib/models.js
+++ b/viewer/lib/models.js
@@ -470,7 +470,7 @@ function matchProperties (block, properties) {
     return properties.OR.some((or) => matchProperties(block, or))
   }
   for (const prop in blockProps) {
-    if (typeof properties[prop] === 'string' && !properties[prop].split('|').some((value) => value === blockProps[prop])) {
+    if (typeof properties[prop] === 'string' && !properties[prop].split('|').some((value) => value === blockProps[prop] + "")) {
       return false
     }
   }

--- a/viewer/lib/models.js
+++ b/viewer/lib/models.js
@@ -470,7 +470,7 @@ function matchProperties (block, properties) {
     return properties.OR.some((or) => matchProperties(block, or))
   }
   for (const prop in blockProps) {
-    if (typeof properties[prop] === 'string' && !properties[prop].split('|').some((value) => value === blockProps[prop] + "")) {
+    if (typeof properties[prop] === 'string' && !properties[prop].split('|').some((value) => value === blockProps[prop] + '')) {
       return false
     }
   }

--- a/viewer/lib/models.js
+++ b/viewer/lib/models.js
@@ -470,7 +470,7 @@ function matchProperties (block, properties) {
     return properties.OR.some((or) => matchProperties(block, or))
   }
   for (const prop in blockProps) {
-    if (properties[prop] !== undefined && !properties[prop].split('|').some((value) => value === (blockProps[prop] + ''))) {
+    if (typeof properties[prop] === 'string' && !properties[prop].split('|').some((value) => value === blockProps[prop])) {
       return false
     }
   }

--- a/viewer/lib/models.js
+++ b/viewer/lib/models.js
@@ -466,8 +466,11 @@ function matchProperties (block, properties) {
 
   properties = parseProperties(properties)
   const blockProps = block.getProperties()
+  if (properties["OR"]) {
+    return properties["OR"].some((or) => matchProperties(block, or))
+  }
   for (const prop in blockProps) {
-    if (properties[prop] !== undefined && (blockProps[prop] + '') !== properties[prop]) {
+    if (properties[prop] !== undefined && !properties[prop].split("|").some((value) => value == (blockProps[prop] + ''))) {
       return false
     }
   }


### PR DESCRIPTION
Redstone Wire wasn't rendered properly because prismarine-viewer didn't process `OR` key of `blocks_states.json`

Before:
![image](https://user-images.githubusercontent.com/33594303/221399234-11a69230-1184-4600-b751-6e897d8a72c6.png)

After:
![image](https://user-images.githubusercontent.com/33594303/221399172-d243190e-ce05-42cc-b618-56bb2ded3811.png)
