### PR TITLE
Fix: RangeError maximum call stack size exceeded

### DIFF
--- a/viewer/lib/dispose.js
+++ b/viewer/lib/dispose.js
@@ -1,37 +1,72 @@
-const THREE = require('three')
+const THREE = require('three');  
+  
+/**  
+ * Recursively removes objects from the Three.js scene and disposes them from memory.  
+ * @param {Object} object - The object or group of objects to be removed and disposed from memory.
+ * @param {Set} visited - Set of objects already visited to prevent duplicate removals of objects.
+ */
+function dispose3(object, visited = new Set()) {  
+  try {  
+    if (visited.has(object)) return;  
+    visited.add(object);  
+  
+    if (object && typeof object === 'object') {  
+      if (Array.isArray(object)) {  
+        object.forEach(element => dispose3(element, visited));  
+      } else {  
+        disposeObject3D(object, visited);  
+      }  
+    }  
+  } catch (error) {  
+    console.log(error);  
+  }  
+}  
+  
+function disposeObject3D(object, visited) {  
+  if (object instanceof THREE.Object3D) {  
+    dispose3(object.geometry, visited);  
+    dispose3(object.material, visited);  
+    removeParent(object);  
+    dispose3(object.children, visited);  
+  } else {  
+    disposeBufferGeometry(object);  
+    disposeMaterial(object, visited);  
+    disposeOtherObjects(object, visited);  
+  }  
+}  
+  
+function removeParent(object) {  
+  if (object.parent) {  
+    object.parent.remove(object);  
+  }  
+}  
+  
+function disposeBufferGeometry(object) {  
+  if (object instanceof THREE.BufferGeometry) {  
+    object.dispose();  
+  }  
+}  
+  
+function disposeMaterial(object, visited) {  
+  if (object instanceof THREE.Material) {  
+    object.dispose();  
+    dispose3(object.materials, visited);  
+    dispose3(object.map, visited);  
+    dispose3(object.lightMap, visited);  
+    dispose3(object.bumpMap, visited);  
+    dispose3(object.normalMap, visited);  
+    dispose3(object.specularMap, visited);  
+    dispose3(object.envMap, visited);  
+  }  
+}  
+  
+function disposeOtherObjects(object, visited) {  
+  if (typeof object.dispose === 'function') {  
+    object.dispose();  
+  } else {  
+    Object.values(object).forEach(element => dispose3(element, visited));  
+  }  
+}  
+  
+module.exports = { dispose3 };  
 
-function dispose3 (o) {
-  try {
-    if (o && typeof o === 'object') {
-      if (Array.isArray(o)) {
-        o.forEach(dispose3)
-      } else if (o instanceof THREE.Object3D) {
-        dispose3(o.geometry)
-        dispose3(o.material)
-        if (o.parent) {
-          o.parent.remove(o)
-        }
-        dispose3(o.children)
-      } else if (o instanceof THREE.BufferGeometry) {
-        o.dispose()
-      } else if (o instanceof THREE.Material) {
-        o.dispose()
-        dispose3(o.materials)
-        dispose3(o.map)
-        dispose3(o.lightMap)
-        dispose3(o.bumpMap)
-        dispose3(o.normalMap)
-        dispose3(o.specularMap)
-        dispose3(o.envMap)
-      } else if (typeof o.dispose === 'function') {
-        o.dispose()
-      } else {
-        Object.values(o).forEach(dispose3)
-      }
-    }
-  } catch (error) {
-    console.log(error)
-  }
-}
-
-module.exports = { dispose3 }


### PR DESCRIPTION
The original dispose3 function was a recursive function that checks if the object passed as a parameter is an instance of certain classes and disposes of them accordingly. The refactored version is also recursive but separates the logic into smaller functions that are easier to read and maintain.

The dispose3 function takes two parameters, the object to be disposed of, and a set of visited objects to prevent duplicate removals. If the object is an array, it iterates through each element and calls the dispose3 function recursively. If it is not an array, it calls the disposeObject3D function.

The disposeObject3D function checks if the object is an instance of THREE.Object3D and disposes of its geometry, material, and children. If it is not an instance of THREE.Object3D, it calls the disposeBufferGeometry, disposeMaterial, and disposeOtherObjects functions to dispose of the object and any materials or textures it contains.

The removeParent function removes the object from its parent if it has one, and the disposeBufferGeometry function disposes of the buffer geometry if it is an instance of THREE.BufferGeometry. The disposeMaterial function disposes of the material and any textures it contains if it is an instance of THREE.Material. Finally, the disposeOtherObjects function disposes of any other objects not covered by the previous functions.

Overall, this refactored version of dispose3 is more readable, maintainable, and less prone to memory overflow errors.