### PR TITLE
Roll back/update tweenjs to 19.0.0 (latest working version)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     ]
   },
   "dependencies": {
-    "@tweenjs/tween.js": "^20.0.3",
+    "@tweenjs/tween.js": "^18.6.4",
     "compression": "^1.7.4",
     "express": "^4.17.1",
     "minecraft-data": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     ]
   },
   "dependencies": {
-    "@tweenjs/tween.js": "^18.6.4",
+    "@tweenjs/tween.js": "^19.0.0",
     "compression": "^1.7.4",
     "express": "^4.17.1",
     "minecraft-data": "^3.0.0",


### PR DESCRIPTION
this is no permanent fix as is nice to have a package up-to-date but for now until https://github.com/tweenjs/tween.js/pull/659 is merged it works