### PR TITLE
Added support for proxy

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,9 @@ require('three/examples/js/controls/OrbitControls')
 const { Viewer, Entity } = require('../viewer')
 
 const io = require('socket.io-client')
-const socket = io()
+const socket = io({
+  path: window.location.pathname + 'socket.io'
+})
 
 let firstPositionUpdate = true
 


### PR DESCRIPTION
Hi guys, I added a small change to the brackets behind the proxy.

If path is not specified, socket.io gets the "root" /socket.io but when under dynamic proxy it must be a dynamic path