### PR TITLE
Focus to point (and type declaration addition)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,38 +1,58 @@
 import {Bot} from "mineflayer";
+import { Vec3 } from "vec3";
+import { EventEmitter } from 'events';
 
-export function mineflayer(bot: Bot, settings: {
-    viewDistance?: number;
-    firstPerson?: boolean;
-    port?: number;
-    prefix?: string;
-});
+declare module 'prismarine-viewer' {
+    export function mineflayer(bot: Bot, settings: {
+        viewDistance?: number;
+        firstPerson?: boolean;
+        port?: number;
+        prefix?: string;
+    });
 
-export function standalone(options: {
-    version: versions;
-    world: (x: number, y: number, z: number) => 0 | 1;
-    center?: Vec3;
-    viewDistance?: number;
-    port?: number;
-    prefix?: string;
-});
+    export function standalone(options: {
+        version: versions;
+        world: (x: number, y: number, z: number) => 0 | 1;
+        center?: Vec3;
+        viewDistance?: number;
+        port?: number;
+        prefix?: string;
+    });
 
-export function headless(bot: Bot, settings: {
-    viewDistance?: number;
-    output?: string;
-    frames?: number;
-    width?: number;
-    height?: number;
-    logFFMPEG?: boolean;
-    jpegOption: any;
-});
+    export function headless(bot: Bot, settings: {
+        viewDistance?: number;
+        output?: string;
+        frames?: number;
+        width?: number;
+        height?: number;
+        logFFMPEG?: boolean;
+        jpegOption: any;
+    });
 
-export const viewer: {
-    Viewer: any;
-    WorldView: any;
-    MapControls: any;
-    Entitiy: any;
-    getBufferFromStream: (stream: any) => Promise<Buffer>;
-};
+    export const viewer: {
+        Viewer: any;
+        WorldView: any;
+        MapControls: any;
+        Entitiy: any;
+        getBufferFromStream: (stream: any) => Promise<Buffer>;
+    };
 
-export const supportedVersions: versions[];
-export type versions = '1.8.8' | '1.9.4' | '1.10.2' | '1.11.2' | '1.12.2' | '1.13.2' | '1.14.4' | '1.15.2' | '1.16.1' | '1.16.4' | '1.17.1' | '1.18.1';
+    export const supportedVersions: versions[];
+    export type versions = '1.8.8' | '1.9.4' | '1.10.2' | '1.11.2' | '1.12.2' | '1.13.2' | '1.14.4' | '1.15.2' | '1.16.1' | '1.16.4' | '1.17.1' | '1.18.1';
+
+}
+
+
+declare module 'mineflayer' {
+	interface Bot {
+		viewer: {
+			erase: (id: string) => void;
+			drawBoxGrid: (id: string, start: Vec3, end: Vec3, color?: string) => void;
+			drawLine: (id: string, points: Vec3[], color?: number) => void;
+			drawPoints: (id: string, points: Vec3[], color?: number, size?: number) => void;
+			close: () => void;
+			on(event: 'blockClicked', listener: (block: any, face: any, button: any) => void): this;
+			emit(event: 'blockClicked', block: any, face: any, button: any): boolean;
+		} & EventEmitter;
+	}
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -50,6 +50,7 @@ declare module 'mineflayer' {
 			drawBoxGrid: (id: string, start: Vec3, end: Vec3, color?: string) => void;
 			drawLine: (id: string, points: Vec3[], color?: number) => void;
 			drawPoints: (id: string, points: Vec3[], color?: number, size?: number) => void;
+			focusPoint: (position: Vec3) => void;
 			close: () => void;
 			on(event: 'blockClicked', listener: (block: any, face: any, button: any) => void): this;
 			emit(event: 'blockClicked', block: any, face: any, button: any): boolean;

--- a/lib/index.js
+++ b/lib/index.js
@@ -43,7 +43,7 @@ socket.on('version', (version) => {
   viewer.listen(socket)
 
   let botMesh
-  socket.on('position', ({ pos, addMesh, yaw, pitch }) => {
+  socket.on('position', ({ pos, addMesh, yaw, pitch, focus }) => {
     if (yaw !== undefined && pitch !== undefined) {
       if (controls) {
         controls.dispose()
@@ -69,5 +69,9 @@ socket.on('version', (version) => {
       const dy = 2 * da % (Math.PI * 2) - da
       new TWEEN.Tween(botMesh.rotation).to({ y: botMesh.rotation.y + dy }, 50).start()
     }
+  })
+
+  socket.on('focusPoint', (pos) => {
+    viewer.focusOnPosition(pos, controls)
   })
 })

--- a/lib/mineflayer.js
+++ b/lib/mineflayer.js
@@ -45,6 +45,12 @@ module.exports = (bot, { viewDistance = 6, firstPerson = false, port = 3000, pre
     }
   }
 
+  bot.viewer.focusPoint = (position) => {
+    for (const socket of sockets) {
+      socket.emit('focusPoint', position)
+    }
+  }
+
   io.on('connection', (socket) => {
     socket.emit('version', bot.version)
     sockets.push(socket)

--- a/lib/mineflayer.js
+++ b/lib/mineflayer.js
@@ -79,7 +79,7 @@ module.exports = (bot, { viewDistance = 6, firstPerson = false, port = 3000, pre
   })
 
   http.listen(port, () => {
-    console.log(`Prismarine viewer web server running on *:${port}`)
+    // console.log(`Prismarine viewer web server running on *:${port}`)
   })
 
   bot.viewer.close = () => {

--- a/viewer/lib/viewer.js
+++ b/viewer/lib/viewer.js
@@ -82,6 +82,31 @@ class Viewer {
     this.camera.rotation.set(pitch, yaw, 0, 'ZYX')
   }
 
+  focusOnPosition(pos, controls) {
+    if(controls) {
+      // Calculate the initial offset between the camera (controls.object) and its current target
+      const initialOffset = new THREE.Vector3().subVectors(controls.object.position, controls.target);
+
+      // Set the end position for the target
+      const newTarget = new THREE.Vector3(pos.x, pos.y, pos.z);
+
+      // Start a tween for the target
+      new TWEEN.Tween(controls.target)
+          .to({x: newTarget.x, y: newTarget.y, z: newTarget.z}, 800)
+          .easing(TWEEN.Easing.Quadratic.InOut)
+          .onUpdate(() => {
+              // As the target moves, calculate the new position for the camera using the updated target and the initial offset
+              controls.object.position.x = controls.target.x + initialOffset.x;
+              controls.object.position.y = controls.target.y + initialOffset.y;
+              controls.object.position.z = controls.target.z + initialOffset.z;
+
+              // Optional: Update the controls in each frame if needed
+              controls.update();
+          })
+          .start();
+    }
+  }
+
   listen (emitter) {
     emitter.on('entity', (e) => {
       this.updateEntity(e)


### PR DESCRIPTION
Now, you can simply do `bot.viewer.focusPoint(vec3)` to focus your third person viewport to a specific point! (it will smoothy transition there)

This PR also removes the unnecessary `console.log` (which would break custom CLI handling like spinners etc) and adds type declarations for the whole viewer.