### PR TITLE
Fix headless

### DIFF
--- a/viewer/lib/entities.js
+++ b/viewer/lib/entities.js
@@ -4,15 +4,19 @@ const TWEEN = require('@tweenjs/tween.js')
 const Entity = require('./entity/Entity')
 const { dispose3 } = require('./dispose')
 
+const { createCanvas } = require('canvas')
+
 function getEntityMesh (entity, scene) {
   if (entity.name) {
     try {
       const e = new Entity('1.16.4', entity.name, scene)
 
       if (entity.username !== undefined) {
-        const canvas = document.createElement('canvas')
-        canvas.width = 500
-        canvas.height = 100
+        // Referencing document breaks headless
+        // const canvas = document.createElement('canvas')
+        // canvas.width = 500
+        // canvas.height = 100
+        const canvas = createCanvas(500, 100)
 
         const ctx = canvas.getContext('2d')
         ctx.font = '50pt Arial'

--- a/viewer/lib/entities.js
+++ b/viewer/lib/entities.js
@@ -12,10 +12,6 @@ function getEntityMesh (entity, scene) {
       const e = new Entity('1.16.4', entity.name, scene)
 
       if (entity.username !== undefined) {
-        // Referencing document breaks headless
-        // const canvas = document.createElement('canvas')
-        // canvas.width = 500
-        // canvas.height = 100
         const canvas = createCanvas(500, 100)
 
         const ctx = canvas.getContext('2d')

--- a/viewer/lib/entity/entities.json
+++ b/viewer/lib/entity/entities.json
@@ -11192,8 +11192,7 @@
       "animated": "player_animated"
     },
     "textures": {
-      "default": "textures/entity/steve",
-      "cape": "textures/entity/cape_invisible"
+      "default": "textures/entity/steve"
     },
     "geometry": {
       "default": {


### PR DESCRIPTION
Two changes to fix headless:

- remove unused invisible_cape texture on player
- use node-canvas in getEntityMesh()