### PR TITLE
Fix entity rotation: handle yaw=0 + correct shortest-path math

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -67,9 +67,12 @@ socket.on('version', (version) => {
       }
       new TWEEN.Tween(botMesh.position).to({ x: pos.x, y: pos.y, z: pos.z }, 50).start()
 
-      const da = (yaw - botMesh.rotation.y) % (Math.PI * 2)
-      const dy = 2 * da % (Math.PI * 2) - da
-      new TWEEN.Tween(botMesh.rotation).to({ y: botMesh.rotation.y + dy }, 50).start()
+      if (typeof yaw === 'number' && Number.isFinite(yaw)) {
+        const TAU = Math.PI * 2
+        const norm = ((yaw - botMesh.rotation.y) % TAU + TAU) % TAU
+        const dy = norm > Math.PI ? norm - TAU : norm
+        new TWEEN.Tween(botMesh.rotation).to({ y: botMesh.rotation.y + dy }, 50).start()
+      }
     }
   })
 })

--- a/viewer/lib/entities.js
+++ b/viewer/lib/entities.js
@@ -77,9 +77,10 @@ class Entities {
     if (entity.pos) {
       new TWEEN.Tween(e.position).to({ x: entity.pos.x, y: entity.pos.y, z: entity.pos.z }, 50).start()
     }
-    if (entity.yaw) {
-      const da = (entity.yaw - e.rotation.y) % (Math.PI * 2)
-      const dy = 2 * da % (Math.PI * 2) - da
+    if (typeof entity.yaw === 'number' && Number.isFinite(entity.yaw)) {
+      const TAU = Math.PI * 2
+      const norm = ((entity.yaw - e.rotation.y) % TAU + TAU) % TAU
+      const dy = norm > Math.PI ? norm - TAU : norm
       new TWEEN.Tween(e.rotation).to({ y: e.rotation.y + dy }, 50).start()
     }
   }


### PR DESCRIPTION
The entity rotation update path had two latent bugs that caused player models to snap to wrong orientations:

1. **`if (entity.yaw)` skips yaw=0** — `0` is a perfectly valid yaw (facing south in MC convention), but the truthy check treats it as falsy and skips the rotation update entirely, leaving the model at whatever rotation it had from a previous frame.

2. **Shortest-path math regression** — `((2 * da) % 2π) - da` doesn't always pick the geodesic on the unit circle when `entity.yaw - e.rotation.y` lands in certain quadrants, so models occasionally rotate the long way (≈2π−ε in the opposite direction).

### Fix

```diff
-    if (entity.yaw) {
-      const da = (entity.yaw - e.rotation.y) % (Math.PI * 2)
-      const dy = 2 * da % (Math.PI * 2) - da
+    if (typeof entity.yaw === 'number' && Number.isFinite(entity.yaw)) {
+      const TAU = Math.PI * 2
+      const norm = ((entity.yaw - e.rotation.y) % TAU + TAU) % TAU
+      const dy = norm > Math.PI ? norm - TAU : norm
       new TWEEN.Tween(e.rotation).to({ y: e.rotation.y + dy }, 50).start()
     }
```

The new formula is the textbook "wrap to (-π, π]" shortest-rotation calculation. The same change is applied to the bot's own model in `lib/index.js`.

### Note

The most user-visible "models snap on jump" symptom of this code path was actually rooted in a mineflayer bug (PrismarineJS/mineflayer#3896 — `sync_entity_position` not converting notchian yaw → radians). With that mineflayer fix in place, these viewer issues are still observable but more subtly: models facing exactly north (yaw=0) keep stale rotation, and occasional long-way-round spins on large yaw deltas. Worth fixing here too.