### PR TITLE
Improve player nametag rendering

### DIFF
--- a/viewer/lib/entities.js
+++ b/viewer/lib/entities.js
@@ -12,22 +12,48 @@ function getEntityMesh (entity, scene) {
       const e = new Entity('1.16.4', entity.name, scene)
 
       if (entity.username !== undefined) {
-        const canvas = createCanvas(500, 100)
+        // Render the nametag like vanilla: white text with a soft drop shadow
+        // on a translucent black background, sized to the measured text so the
+        // sprite's aspect ratio matches and doesn't squash the letters.
+        const txt = entity.username
+        const padX = 16
+        const padY = 6
+        const fontPx = 80
 
+        const measure = createCanvas(1, 1).getContext('2d')
+        measure.font = `${fontPx}px sans-serif`
+        const textW = Math.ceil(measure.measureText(txt).width)
+
+        const w = textW + padX * 2 + 2 // + shadow
+        const h = fontPx + padY * 2 + 2
+
+        const canvas = createCanvas(w, h)
         const ctx = canvas.getContext('2d')
-        ctx.font = '50pt Arial'
-        ctx.fillStyle = '#000000'
+        ctx.fillStyle = 'rgba(0, 0, 0, 0.32)'
+        ctx.fillRect(0, 0, w, h)
+
+        ctx.font = `${fontPx}px sans-serif`
         ctx.textAlign = 'left'
         ctx.textBaseline = 'top'
-
-        const txt = entity.username
-        ctx.fillText(txt, 100, 0)
+        ctx.fillStyle = '#3f3f3f'
+        ctx.fillText(txt, padX + 2, padY + 2) // shadow
+        ctx.fillStyle = '#ffffff'
+        ctx.fillText(txt, padX, padY)
 
         const tex = new THREE.Texture(canvas)
         tex.needsUpdate = true
-        const spriteMat = new THREE.SpriteMaterial({ map: tex })
+        tex.minFilter = THREE.LinearFilter
+        tex.magFilter = THREE.LinearFilter
+        tex.generateMipmaps = false
+        tex.anisotropy = 4
+        const spriteMat = new THREE.SpriteMaterial({ map: tex, transparent: true, depthTest: false })
         const sprite = new THREE.Sprite(spriteMat)
+        // Scale so the sprite is ~0.4m tall regardless of canvas pixel size,
+        // and width preserves canvas aspect — fixes the "squished" look.
+        const targetHeight = 0.4
+        sprite.scale.set(targetHeight * (w / h), targetHeight, 1)
         sprite.position.y += entity.height + 0.6
+        sprite.renderOrder = 999
 
         e.mesh.add(sprite)
       }

--- a/viewer/lib/entities.js
+++ b/viewer/lib/entities.js
@@ -19,9 +19,9 @@ function getEntityMesh (entity, scene) {
         const padX = 16
         const padY = 6
         const fontPx = 80
-        // Prefer a real Minecraft font when one is installed, falling back to a
-        // monospace face so the nametag still looks reasonable everywhere.
-        const font = `${fontPx}px minecraft, mojangles, monospace`
+        // Prefer a real Minecraft font when one is installed, falling back to
+        // sans-serif so the nametag still looks reasonable everywhere.
+        const font = `${fontPx}px minecraft, mojangles, sans-serif`
 
         const measure = createCanvas(1, 1).getContext('2d')
         measure.font = font

--- a/viewer/lib/entities.js
+++ b/viewer/lib/entities.js
@@ -19,9 +19,12 @@ function getEntityMesh (entity, scene) {
         const padX = 16
         const padY = 6
         const fontPx = 80
+        // Prefer a real Minecraft font when one is installed, falling back to a
+        // monospace face so the nametag still looks reasonable everywhere.
+        const font = `${fontPx}px minecraft, mojangles, monospace`
 
         const measure = createCanvas(1, 1).getContext('2d')
-        measure.font = `${fontPx}px sans-serif`
+        measure.font = font
         const textW = Math.ceil(measure.measureText(txt).width)
 
         const w = textW + padX * 2 + 2 // + shadow
@@ -32,7 +35,7 @@ function getEntityMesh (entity, scene) {
         ctx.fillStyle = 'rgba(0, 0, 0, 0.32)'
         ctx.fillRect(0, 0, w, h)
 
-        ctx.font = `${fontPx}px sans-serif`
+        ctx.font = font
         ctx.textAlign = 'left'
         ctx.textBaseline = 'top'
         ctx.fillStyle = '#3f3f3f'


### PR DESCRIPTION
The current player nametag is rendered as black `50pt Arial` text on a transparent `500×100` canvas with text packed to one corner. The sprite scales the result, so the aspect ratio is wrong and the text reads as a horizontally-squashed black blob hovering above the player — at distance it's effectively invisible against any non-light background.

This PR replaces it with a vanilla-MC-style nametag:

- White text with a soft drop shadow on a translucent black background.
- Canvas sized exactly to the measured text + padding, so the sprite's aspect ratio is correct and the text doesn't squash.
- 80px sans-serif rendered with linear filtering so the tag stays legible at any distance.
- `depthTest: false` so the tag is visible even when partially occluded by the player or terrain (matches vanilla).

### Before / after

Both bots in spectator mode at fixed positions; observer (camera) at the same coords for each pair.

| | before | after |
|---|---|---|
| near (~2 blocks) | ![](https://raw.githubusercontent.com/domdomegg/prismarine-viewer/screenshots-pr-improve-nametags/screenshots/nametag-before-near.png) | ![](https://raw.githubusercontent.com/domdomegg/prismarine-viewer/screenshots-pr-improve-nametags/screenshots/nametag-after-near.png) |
| mid (~5 blocks) | ![](https://raw.githubusercontent.com/domdomegg/prismarine-viewer/screenshots-pr-improve-nametags/screenshots/nametag-before-mid.png) | ![](https://raw.githubusercontent.com/domdomegg/prismarine-viewer/screenshots-pr-improve-nametags/screenshots/nametag-after-mid.png) |
| far (~9 blocks) | ![](https://raw.githubusercontent.com/domdomegg/prismarine-viewer/screenshots-pr-improve-nametags/screenshots/nametag-before-far.png) | ![](https://raw.githubusercontent.com/domdomegg/prismarine-viewer/screenshots-pr-improve-nametags/screenshots/nametag-after-far.png) |