### PR TITLE
Render negative-Y sections on 1.18+ worlds

### DIFF
--- a/viewer/lib/models.js
+++ b/viewer/lib/models.js
@@ -130,7 +130,7 @@ function renderLiquid (world, cursor, texture, type, biome, water, attr) {
     if (!neighbor) continue
     if (neighbor.type === type) continue
     if ((neighbor.isCube && !isUp) || neighbor.material === 'plant' || neighbor.getProperties().waterlogged) continue
-    if (neighbor.position.y < 0) continue
+    if (neighbor.position.y < (world.minY ?? 0)) continue
 
     let tint = [1, 1, 1]
     if (water) {
@@ -241,7 +241,7 @@ function renderElement (world, cursor, element, doAO, attr, globalMatrix, global
       if (!neighbor) continue
       if (cullIfIdentical && neighbor.type === block.type) continue
       if (!neighbor.transparent && neighbor.isCube) continue
-      if (neighbor.position.y < 0) continue
+      if (neighbor.position.y < (world.minY ?? 0)) continue
     }
 
     const minx = element.from[0]

--- a/viewer/lib/worker.js
+++ b/viewer/lib/worker.js
@@ -32,7 +32,7 @@ function setSectionDirty (pos, value = true) {
   if (!value) {
     delete dirtySections[key]
     postMessage({ type: 'sectionFinished', key })
-  } else if (chunk && chunk.sections[Math.floor(y / 16)]) {
+  } else if (chunk && chunk.sections[(y - (chunk.minY ?? 0)) / 16]) {
     dirtySections[key] = value
   } else {
     postMessage({ type: 'sectionFinished', key })
@@ -74,7 +74,7 @@ setInterval(() => {
     y = parseInt(y, 10)
     z = parseInt(z, 10)
     const chunk = world.getColumn(x, z)
-    if (chunk && chunk.sections[Math.floor(y / 16)]) {
+    if (chunk && chunk.sections[(y - (chunk.minY ?? 0)) / 16]) {
       delete dirtySections[key]
       const geometry = getSectionGeometry(x, y, z, world, blocksStates)
       const transferable = [geometry.positions.buffer, geometry.normals.buffer, geometry.colors.buffer, geometry.uvs.buffer]

--- a/viewer/lib/world.js
+++ b/viewer/lib/world.js
@@ -24,6 +24,8 @@ class World {
     this.columns = {}
     this.blockCache = {}
     this.biomeCache = mcData(version).biomes
+    // 0 before 1.18, -64 after — used by models.js to cull out-of-world faces
+    this.minY = new this.Chunk().minY ?? 0
   }
 
   addColumn (x, z, json) {

--- a/viewer/lib/worldrenderer.js
+++ b/viewer/lib/worldrenderer.js
@@ -4,6 +4,7 @@ const Vec3 = require('vec3').Vec3
 const { loadTexture, loadJSON } = globalThis.isElectron ? require('./utils.electron.js') : require('./utils')
 const { EventEmitter } = require('events')
 const { dispose3 } = require('./dispose')
+const Chunks = require('prismarine-chunk')
 
 function mod (x, n) {
   return ((x % n) + n) % n
@@ -14,6 +15,10 @@ class WorldRenderer {
     this.sectionMeshs = {}
     this.active = false
     this.version = undefined
+    // World Y bounds; overwritten in setVersion from the version's chunk
+    // implementation (negative-Y worlds since 1.18). Defaults match pre-1.18.
+    this.minY = 0
+    this.worldHeight = 256
     this.scene = scene
     this.loadedChunks = {}
     this.sectionsOutstanding = new Set()
@@ -77,6 +82,9 @@ class WorldRenderer {
 
   setVersion (version) {
     this.version = version
+    const chunk = new (Chunks(version))()
+    this.minY = chunk.minY ?? 0
+    this.worldHeight = chunk.worldHeight ?? 256
     this.resetWorld()
     this.active = true
     for (const worker of this.workers) {
@@ -112,7 +120,7 @@ class WorldRenderer {
     for (const worker of this.workers) {
       worker.postMessage({ type: 'chunk', x, z, chunk })
     }
-    for (let y = 0; y < 256; y += 16) {
+    for (let y = this.minY; y < this.minY + this.worldHeight; y += 16) {
       const loc = new Vec3(x, y, z)
       this.setSectionDirty(loc)
       this.setSectionDirty(loc.offset(-16, 0, 0))
@@ -127,7 +135,7 @@ class WorldRenderer {
     for (const worker of this.workers) {
       worker.postMessage({ type: 'unloadChunk', x, z })
     }
-    for (let y = 0; y < 256; y += 16) {
+    for (let y = this.minY; y < this.minY + this.worldHeight; y += 16) {
       this.setSectionDirty(new Vec3(x, y, z), false)
       const key = `${x},${y},${z}`
       const mesh = this.sectionMeshs[key]


### PR DESCRIPTION
Stacked on #484 — merge that first, after which this PR's diff collapses to just the last commit.

## Problem

Any camera below y=0 renders nothing but the clear color — e.g. a mineflayer bot standing in a deepslate cave shows a uniform sky-blue frame, even with the surrounding chunks fully loaded.

## Cause

- `worldrenderer.js` hardcodes the pre-1.18 world range: the dirty-section loops in `addColumn`/`removeColumn` iterate `y = 0..240`, so sections below y=0 are never queued for meshing.
- `worker.js`'s section-presence guard indexes `chunk.sections[Math.floor(y / 16)]`, but `ChunkColumn` (1.18+) indexes sections from `minY` (-64): `sections[(pos.y - this.minY) >> 4]`. For y < 16 sections this resolves to the wrong index, and for y < 0 to `sections[-1]` = undefined, so those sections are skipped. (Above ground it is accidentally harmless — sections are dense and geometry is read via absolute coordinates — but the guard checks the wrong slot.)
- `models.js` culls faces against a hardcoded `y < 0` instead of the world's `minY`.

## Fix

- Derive `minY`/`worldHeight` from the version's chunk implementation in `setVersion` (defaults `0`/`256`, so pre-1.18 behavior is unchanged) and iterate the real range in `addColumn`/`removeColumn`.
- Index worker sections by `(y - (chunk.minY ?? 0)) / 16`.
- Expose `minY` on the worker's `World` wrapper and gate `models.js` face culling on `world.minY ?? 0`.

## Verification

- `setVersion('26.1')` → `{ minY: -64, worldHeight: 384 }`; `1.16.5` / `1.12.2` → `{ 0, 256 }` (`new Chunk()` constructs fine on old versions)
- A 26.1 column with a block set at y=-7 round-trips through `World.addColumn(fromJson)`: the y=-16 section resolves and the block reads back through `world.getBlock`
- `addColumn` on 26.1 now queues 20 negative-Y section jobs per column (previously 0)