### PR TITLE
Fix rendering of terrain below y=0 (1.18+ / superflat / deepslate)

### DIFF
--- a/viewer/lib/models.js
+++ b/viewer/lib/models.js
@@ -241,7 +241,8 @@ function renderElement (world, cursor, element, doAO, attr, globalMatrix, global
       if (!neighbor) continue
       if (cullIfIdentical && neighbor.type === block.type) continue
       if (!neighbor.transparent && neighbor.isCube) continue
-      if (neighbor.position.y < 0) continue
+      // (removed: `if (neighbor.position.y < 0) continue` — it culled every face
+      // whose neighbor sits below y=0, breaking all terrain in 1.18+ negative-Y worlds.)
     }
 
     const minx = element.from[0]

--- a/viewer/lib/worker.js
+++ b/viewer/lib/worker.js
@@ -32,7 +32,9 @@ function setSectionDirty (pos, value = true) {
   if (!value) {
     delete dirtySections[key]
     postMessage({ type: 'sectionFinished', key })
-  } else if (chunk && chunk.sections[Math.floor(y / 16)]) {
+  } else if (chunk) {
+    // Mesh any section of a loaded chunk. (The old chunk.sections[y/16] check
+    // used a 0-based index that is wrong for 1.18+ negative-Y worlds.)
     dirtySections[key] = value
   } else {
     postMessage({ type: 'sectionFinished', key })
@@ -74,7 +76,9 @@ setInterval(() => {
     y = parseInt(y, 10)
     z = parseInt(z, 10)
     const chunk = world.getColumn(x, z)
-    if (chunk && chunk.sections[Math.floor(y / 16)]) {
+    if (chunk) {
+      // Mesh any section of a loaded chunk. (The old chunk.sections[y/16] index
+      // was wrong for 1.18+ negative-Y worlds and skipped all sub-zero terrain.)
       delete dirtySections[key]
       const geometry = getSectionGeometry(x, y, z, world, blocksStates)
       const transferable = [geometry.positions.buffer, geometry.normals.buffer, geometry.colors.buffer, geometry.uvs.buffer]

--- a/viewer/lib/worldrenderer.js
+++ b/viewer/lib/worldrenderer.js
@@ -112,7 +112,7 @@ class WorldRenderer {
     for (const worker of this.workers) {
       worker.postMessage({ type: 'chunk', x, z, chunk })
     }
-    for (let y = 0; y < 256; y += 16) {
+    for (let y = -64; y < 320; y += 16) {
       const loc = new Vec3(x, y, z)
       this.setSectionDirty(loc)
       this.setSectionDirty(loc.offset(-16, 0, 0))
@@ -127,7 +127,7 @@ class WorldRenderer {
     for (const worker of this.workers) {
       worker.postMessage({ type: 'unloadChunk', x, z })
     }
-    for (let y = 0; y < 256; y += 16) {
+    for (let y = -64; y < 320; y += 16) {
       this.setSectionDirty(new Vec3(x, y, z), false)
       const key = `${x},${y},${z}`
       const mesh = this.sectionMeshs[key]


### PR DESCRIPTION
### Problem

Terrain below `y=0` never renders. Three spots hardcode the pre-1.18 world floor (`y=0`):

1. `WorldRenderer.addColumn`/`removeColumn` only mark sections dirty for `y = 0; y < 256`, so sections below `y=0` are never queued for meshing.
2. The worker's mesh loop and `setSectionDirty` gate on `chunk.sections[Math.floor(y / 16)]` — but that 0-based index is negative (hence `undefined`) for `y < 0`, so every sub-zero section is treated as empty.
3. `renderElement` has `if (neighbor.position.y < 0) continue`, which culls **every** face whose neighbour block sits below `y=0`.

Net effect on 1.18+ worlds: deepslate layers, anything below `y=0`, and **entire flat/superflat worlds** (surface at ~`y=-60`) render as blank sky.

### Fix

- Mesh across the full 1.18+ height (`y = -64 .. 320`) in `worldrenderer.js`.
- Drop the `chunk.sections[Math.floor(y / 16)]` guards in `worker.js` (mesh any section of a loaded chunk; genuinely-empty sections just produce empty geometry).
- Remove the `neighbor.position.y < 0` face cull in `models.js`.

Three small, self-contained changes; no dependency or API changes.

### Testing

Rendered a **1.21.8 superflat** world (surface at `y=-60`) headlessly via `Viewer` + `WorldView`. Before: blank sky. After: terrain and structures render correctly with textures and block models.

Found while building a headless (Node) renderer on top of prismarine-viewer.
