### PR TITLE
Make the node viewer loadable without node-canvas

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "compression": "^1.7.4",
     "express": "^4.17.1",
     "minecraft-data": "^3.0.0",
+    "pngjs": "^7.0.0",
     "prismarine-block": "^1.7.3",
     "prismarine-chunk": "^1.22.0",
     "prismarine-world": "^3.3.1",

--- a/viewer/lib/entities.js
+++ b/viewer/lib/entities.js
@@ -4,14 +4,15 @@ const TWEEN = require('@tweenjs/tween.js')
 const Entity = require('./entity/Entity')
 const { dispose3 } = require('./dispose')
 
-const { createCanvas } = require('canvas')
+let createCanvas
+try { ({ createCanvas } = require('canvas')) } catch {}
 
 function getEntityMesh (entity, scene) {
   if (entity.name) {
     try {
       const e = new Entity('1.16.4', entity.name, scene)
 
-      if (entity.username !== undefined) {
+      if (entity.username !== undefined && createCanvas) {
         const canvas = createCanvas(500, 100)
 
         const ctx = canvas.getContext('2d')

--- a/viewer/lib/utils.js
+++ b/viewer/lib/utils.js
@@ -5,9 +5,10 @@ function safeRequire (path) {
     return {}
   }
 }
-const { loadImage } = safeRequire('node-canvas-webgl/lib')
+const { PNG } = safeRequire('pngjs')
 const THREE = require('three')
 const path = require('path')
+const fs = require('fs')
 
 const textureCache = {}
 // todo not ideal, export different functions for browser and node
@@ -19,10 +20,11 @@ function loadTexture (texture, cb) {
   if (textureCache[texture]) {
     cb(textureCache[texture])
   } else {
-    loadImage(path.resolve(__dirname, '../../public/' + texture)).then(image => {
-      textureCache[texture] = new THREE.CanvasTexture(image)
-      cb(textureCache[texture])
-    })
+    const png = PNG.sync.read(fs.readFileSync(path.resolve(__dirname, '../../public/', texture)))
+    const tex = new THREE.DataTexture(new Uint8Array(png.data), png.width, png.height, THREE.RGBAFormat)
+    tex.needsUpdate = true
+    textureCache[texture] = tex
+    cb(tex)
   }
 }
 


### PR DESCRIPTION
Headless consumers hit two hard requires on the `canvas` native module even when they bring their own GL context: `entities.js` needs it for username sprites, and `utils.js` loads textures through node-canvas-webgl's `loadImage`. `canvas` builds from source whenever a prebuilt is missing for the running node ABI, which makes it the most fragile part of a headless install (node-pre-gyp + cairo/pango toolchain).

This makes the canvas require optional (username sprites are skipped when it's absent) and loads textures with `pngjs` into a `THREE.DataTexture`, so `Viewer`/`WorldView` run with just `headless-gl`:

```js
const gl = require('gl')(width, height, { preserveDrawingBuffer: true })
const canvas = { width, height, addEventListener () {}, removeEventListener () {} }
gl.canvas = canvas
const renderer = new THREE.WebGLRenderer({ canvas, context: gl })
```

The browser bundle is unaffected — both touched paths were already node-only (`utils.loadTexture` used node-canvas-webgl via `safeRequire`). `lib/headless.js` keeps working as before when node-canvas-webgl is installed.

We've been running this in production for a while, rendering a first-person bot view to a video track, and are now reusing it for a second app; `require('./viewer')` with no canvas installed loads clean and renders.