### PR TITLE
Fix master CI: apt-get update, webpack 5.110 sideEffects regression, jest teardown race

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         java-version: 21
         java-package: jre
     - name: Install xi
-      run: sudo apt-get install -y libxi-dev libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev build-essential libglu1-mesa-dev libglew-dev
+      run: sudo apt-get update && sudo apt-get install -y libxi-dev libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev build-essential libglu1-mesa-dev libglew-dev
     - run: npm install
     - run: npm run jestTest -- -t ${{ matrix.mcVersion }}
     - uses: actions/upload-artifact@v4

--- a/test/viewer.test.js
+++ b/test/viewer.test.js
@@ -99,9 +99,11 @@ supportedVersions.forEach(function (supportedVersion) {
               if (message.text() !== 'JSHandle@error') {
                 toPrint = `${message.type().substring(0, 3).toUpperCase()} ${message.text()}`
               } else {
+                // getProperty rejects if the browser closes mid-await; don't let that
+                // unhandled rejection kill the jest process after the test is done
                 const messages = await Promise.all(message.args().map((arg) => {
-                  return arg.getProperty('message')
-                }))
+                  return arg.getProperty('message').catch(() => null)
+                })).catch(() => [])
 
                 toPrint = `${message.type().substring(0, 3).toUpperCase()} ${messages.filter(Boolean)}`
               }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,6 +21,15 @@ const indexConfig = {
       zlib: false
     }
   },
+  module: {
+    rules: [
+      {
+        // three declares sideEffects: false, but examples/js scripts work by attaching to the THREE global
+        test: /three[/\\]examples[/\\]js/,
+        sideEffects: true
+      }
+    ]
+  },
   plugins: [
     // fix "process is not defined" error:
     new webpack.ProvidePlugin({


### PR DESCRIPTION
Master CI currently fails on every PR for three stacked environmental reasons; this bundles the three small fixes (all previously validated on the green #484 run):

1. **apt 404s** — the build jobs install from the runner image's stale package index (no `apt-get update`, unlike Lint), so rotated .deb versions 404 before `npm install` runs. Fix: `sudo apt-get update &&` first.
2. **`THREE.OrbitControls is not a constructor`** — fresh installs pull webpack 5.110.x, which now honors `three@0.128.0`'s incorrect `sideEffects: false` and drops the bare `require('three/examples/js/controls/OrbitControls')` from the bundle, blanking every render. Fix: a `sideEffects: true` module rule for `three/examples/js` in the index config.
3. **jest killed at teardown** — the console handler's `arg.getProperty('message')` rejects if the browser closes mid-await; on Node 24 the unhandled rejection kills jest before it reports results. Fix: catch the rejection.

Verified end to end on [the #484 run](https://github.com/PrismarineJS/prismarine-viewer/actions/runs/33591676898) equivalents; with only fix 1 the jobs get past install and fail on 2/3, e.g. [build (1.18.1) here](https://github.com/PrismarineJS/prismarine-viewer/actions/runs/33591676898).