### PR TITLE
Render player skins

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Options:
 * `firstPerson` is the view first person ? default: `false`
 * `port` the port for the webserver, default: `3000`
 
-Players are rendered with their skin, wide or slim, when the server sends skin data (online-mode servers).
+Players are rendered with their skin, wide or slim, and cape when the server sends skin data (online-mode servers).
 
 [example](https://github.com/PrismarineJS/prismarine-viewer/blob/master/examples/bot.js)
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Options:
 * `firstPerson` is the view first person ? default: `false`
 * `port` the port for the webserver, default: `3000`
 
-Players are rendered with their skin when the server sends skin data (online-mode servers).
+Players are rendered with their skin, wide or slim, when the server sends skin data (online-mode servers).
 
 [example](https://github.com/PrismarineJS/prismarine-viewer/blob/master/examples/bot.js)
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Options:
 * `firstPerson` is the view first person ? default: `false`
 * `port` the port for the webserver, default: `3000`
 
+Players are rendered with their skin when the server sends skin data (online-mode servers).
+
 [example](https://github.com/PrismarineJS/prismarine-viewer/blob/master/examples/bot.js)
 
 #### standalone

--- a/lib/mineflayer.js
+++ b/lib/mineflayer.js
@@ -12,17 +12,19 @@ module.exports = (bot, { viewDistance = 6, firstPerson = false, port = 3000, pre
   const { setupRoutes } = require('./common')
   setupRoutes(app, prefix)
 
-  app.get(prefix + '/skin/:username', async (req, res) => {
-    const url = bot.players[req.params.username]?.skinData?.url
+  const playerTexture = (key) => async (req, res) => {
+    const url = bot.players[req.params.username]?.skinData?.[key]
     if (!url) return res.sendStatus(404)
     try {
-      const skin = await fetch(url)
-      if (!skin.ok) return res.sendStatus(502)
-      res.type('png').send(Buffer.from(await skin.arrayBuffer()))
+      const texture = await fetch(url)
+      if (!texture.ok) return res.sendStatus(502)
+      res.type('png').send(Buffer.from(await texture.arrayBuffer()))
     } catch (err) {
       res.sendStatus(502)
     }
-  })
+  }
+  app.get(prefix + '/skin/:username', playerTexture('url'))
+  app.get(prefix + '/cape/:username', playerTexture('capeUrl'))
 
   const sockets = []
   const primitives = {}

--- a/lib/mineflayer.js
+++ b/lib/mineflayer.js
@@ -12,6 +12,18 @@ module.exports = (bot, { viewDistance = 6, firstPerson = false, port = 3000, pre
   const { setupRoutes } = require('./common')
   setupRoutes(app, prefix)
 
+  app.get(prefix + '/skin/:username', async (req, res) => {
+    const url = bot.players[req.params.username]?.skinData?.url
+    if (!url) return res.sendStatus(404)
+    try {
+      const skin = await fetch(url)
+      if (!skin.ok) return res.sendStatus(502)
+      res.type('png').send(Buffer.from(await skin.arrayBuffer()))
+    } catch (err) {
+      res.sendStatus(502)
+    }
+  })
+
   const sockets = []
   const primitives = {}
 

--- a/lib/mineflayer.js
+++ b/lib/mineflayer.js
@@ -12,19 +12,18 @@ module.exports = (bot, { viewDistance = 6, firstPerson = false, port = 3000, pre
   const { setupRoutes } = require('./common')
   setupRoutes(app, prefix)
 
-  const playerTexture = (key) => async (req, res) => {
-    const url = bot.players[req.params.username]?.skinData?.[key]
-    if (!url) return res.sendStatus(404)
+  // Proxies player skins and capes for the browser (textures.minecraft.net
+  // sends no CORS headers). Only that host, by texture hash, so it can't be
+  // used as an open proxy.
+  app.get(prefix + '/texture/:hash([0-9a-f]+)', async (req, res) => {
     try {
-      const texture = await fetch(url)
-      if (!texture.ok) return res.sendStatus(502)
+      const texture = await fetch(`https://textures.minecraft.net/texture/${req.params.hash}`)
+      if (!texture.ok) return res.sendStatus(texture.status === 404 ? 404 : 502)
       res.type('png').send(Buffer.from(await texture.arrayBuffer()))
     } catch (err) {
       res.sendStatus(502)
     }
-  }
-  app.get(prefix + '/skin/:username', playerTexture('url'))
-  app.get(prefix + '/cape/:username', playerTexture('capeUrl'))
+  })
 
   const sockets = []
   const primitives = {}

--- a/viewer/lib/entities.js
+++ b/viewer/lib/entities.js
@@ -9,13 +9,10 @@ const { createCanvas } = require('canvas')
 function getEntityMesh (entity, scene) {
   if (entity.name) {
     try {
-      const isPlayer = entity.name === 'player' && entity.username !== undefined
       const textures = {}
-      if (isPlayer) {
-        textures.default = `skin/${encodeURIComponent(entity.username)}`
-        if (entity.cape) textures.cape = `cape/${encodeURIComponent(entity.username)}`
-      }
-      const model = isPlayer && entity.skinModel === 'slim' ? 'player_slim' : entity.name
+      if (entity.skin) textures.default = entity.skin
+      if (entity.cape) textures.cape = entity.cape
+      const model = entity.name === 'player' && entity.skinModel === 'slim' ? 'player_slim' : entity.name
       const e = new Entity('1.16.4', model, scene, textures)
 
       if (entity.username !== undefined) {

--- a/viewer/lib/entities.js
+++ b/viewer/lib/entities.js
@@ -9,8 +9,10 @@ const { createCanvas } = require('canvas')
 function getEntityMesh (entity, scene) {
   if (entity.name) {
     try {
-      const skin = entity.name === 'player' && entity.username !== undefined ? `skin/${encodeURIComponent(entity.username)}` : undefined
-      const e = new Entity('1.16.4', entity.name, scene, skin)
+      const isPlayer = entity.name === 'player' && entity.username !== undefined
+      const skin = isPlayer ? `skin/${encodeURIComponent(entity.username)}` : undefined
+      const model = isPlayer && entity.skinModel === 'slim' ? 'player_slim' : entity.name
+      const e = new Entity('1.16.4', model, scene, skin)
 
       if (entity.username !== undefined) {
         const canvas = createCanvas(500, 100)

--- a/viewer/lib/entities.js
+++ b/viewer/lib/entities.js
@@ -10,9 +10,13 @@ function getEntityMesh (entity, scene) {
   if (entity.name) {
     try {
       const isPlayer = entity.name === 'player' && entity.username !== undefined
-      const skin = isPlayer ? `skin/${encodeURIComponent(entity.username)}` : undefined
+      const textures = {}
+      if (isPlayer) {
+        textures.default = `skin/${encodeURIComponent(entity.username)}`
+        if (entity.cape) textures.cape = `cape/${encodeURIComponent(entity.username)}`
+      }
       const model = isPlayer && entity.skinModel === 'slim' ? 'player_slim' : entity.name
-      const e = new Entity('1.16.4', model, scene, skin)
+      const e = new Entity('1.16.4', model, scene, textures)
 
       if (entity.username !== undefined) {
         const canvas = createCanvas(500, 100)

--- a/viewer/lib/entities.js
+++ b/viewer/lib/entities.js
@@ -9,7 +9,8 @@ const { createCanvas } = require('canvas')
 function getEntityMesh (entity, scene) {
   if (entity.name) {
     try {
-      const e = new Entity('1.16.4', entity.name, scene)
+      const skin = entity.name === 'player' && entity.username !== undefined ? `skin/${encodeURIComponent(entity.username)}` : undefined
+      const e = new Entity('1.16.4', entity.name, scene, skin)
 
       if (entity.username !== undefined) {
         const canvas = createCanvas(500, 100)

--- a/viewer/lib/entity/Entity.js
+++ b/viewer/lib/entity/Entity.js
@@ -159,6 +159,12 @@ function upgradeLegacySkin (texture) {
     ctx.drawImage(image, x, y, w, h, 0, 0, w, h)
     ctx.restore()
   }
+  // A hat layer with no transparent pixel at all is an unused layer, not a helmet (vanilla's "Notch transparency hack")
+  const hat = ctx.getImageData(32, 0, 32, 32)
+  if (!hat.data.some((v, i) => i % 4 === 3 && v < 128)) {
+    for (let i = 3; i < hat.data.length; i += 4) hat.data[i] = 0
+    ctx.putImageData(hat, 32, 0)
+  }
   return new THREE.CanvasTexture(canvas)
 }
 

--- a/viewer/lib/entity/Entity.js
+++ b/viewer/lib/entity/Entity.js
@@ -145,6 +145,15 @@ const legacySkinCopies = [
   [44, 16, -8, 32, 4, 4], [48, 16, -8, 32, 4, 4], [40, 20, 0, 32, 4, 12], [44, 20, -8, 32, 4, 12], [48, 20, -16, 32, 4, 12], [52, 20, -8, 32, 4, 12]
 ]
 
+// The overlay block of a 64x32 skin spans the hat rows and the arm and torso rows. Vanilla
+// clears the block when it holds no transparency at all, then forces the arm and torso rows
+// opaque again, so only the hat is really dropped: an overlay that was never used as one.
+function clearUnusedHat (ctx) {
+  const { data } = ctx.getImageData(32, 0, 32, 32)
+  for (let i = 3; i < data.length; i += 4) if (data[i] < 128) return
+  ctx.clearRect(32, 0, 32, 16)
+}
+
 // Skins predating 1.8 are 64x32; the player geometry samples a 64x64 sheet. Capes are 64x32 by design and never pass through here.
 function upgradeLegacySkin (texture) {
   const image = texture.image
@@ -159,12 +168,7 @@ function upgradeLegacySkin (texture) {
     ctx.drawImage(image, x, y, w, h, 0, 0, w, h)
     ctx.restore()
   }
-  // A hat layer with no transparent pixel at all is an unused layer, not a helmet (vanilla's "Notch transparency hack")
-  const hat = ctx.getImageData(32, 0, 32, 32)
-  if (!hat.data.some((v, i) => i % 4 === 3 && v < 128)) {
-    for (let i = 3; i < hat.data.length; i += 4) hat.data[i] = 0
-    ctx.putImageData(hat, 32, 0)
-  }
+  clearUnusedHat(ctx)
   return new THREE.CanvasTexture(canvas)
 }
 

--- a/viewer/lib/entity/Entity.js
+++ b/viewer/lib/entity/Entity.js
@@ -2,7 +2,8 @@
 
 const entities = require('./entities.json')
 const { loadTexture } = globalThis.isElectron ? require('../utils.electron.js') : require('../utils')
-const { createCanvas } = require('canvas')
+let createCanvas
+try { ({ createCanvas } = require('canvas')) } catch {}
 
 const elemFaces = {
   up: {
@@ -139,37 +140,45 @@ function applyTexture (material, texture) {
   material.needsUpdate = true
 }
 
-// Same rects as vanilla's SkinTextureDownloader.processLegacySkin: the left limbs are mirrored copies of the right ones.
+// [x, y, dx, dy, w, h]: the w*h block at (x, y) is copied to (x + dx, y + dy), mirrored horizontally
 const legacySkinCopies = [
   [4, 16, 16, 32, 4, 4], [8, 16, 16, 32, 4, 4], [0, 20, 24, 32, 4, 12], [4, 20, 16, 32, 4, 12], [8, 20, 8, 32, 4, 12], [12, 20, 16, 32, 4, 12],
   [44, 16, -8, 32, 4, 4], [48, 16, -8, 32, 4, 4], [40, 20, 0, 32, 4, 12], [44, 20, -8, 32, 4, 12], [48, 20, -16, 32, 4, 12], [52, 20, -8, 32, 4, 12]
 ]
 
-// The overlay block of a 64x32 skin spans the hat rows and the arm and torso rows. Vanilla
-// clears the block when it holds no transparency at all, then forces the arm and torso rows
-// opaque again, so only the hat is really dropped: an overlay that was never used as one.
-function clearUnusedHat (ctx) {
-  const { data } = ctx.getImageData(32, 0, 32, 32)
-  for (let i = 3; i < data.length; i += 4) if (data[i] < 128) return
-  ctx.clearRect(32, 0, 32, 16)
+// RGBA rows of a loaded texture. A DataTexture carries them; an image is drawn once to read them.
+function texturePixels (image) {
+  if (image.data) return image.data
+  const ctx = createCanvas(image.width, image.height).getContext('2d')
+  ctx.drawImage(image, 0, 0)
+  return ctx.getImageData(0, 0, image.width, image.height).data
 }
 
-// Skins predating 1.8 are 64x32; the player geometry samples a 64x64 sheet. Capes are 64x32 by design and never pass through here.
+// Skins predating 1.8 are 64x32; the player geometry samples a 64x64 sheet. Same steps as
+// vanilla's HttpTexture.processLegacySkin: the left limbs are mirrored copies of the right
+// ones, and an overlay block with no transparency at all was never used as a hat, so its
+// hat rows are dropped (the arm and torso rows below are base texture and stay). Capes are
+// 64x32 by design and never pass through here.
 function upgradeLegacySkin (texture) {
   const image = texture.image
   if (image.width !== 64 || image.height !== 32) return texture
-  const canvas = createCanvas(64, 64)
-  const ctx = canvas.getContext('2d')
-  ctx.drawImage(image, 0, 0)
+  const src = texturePixels(image)
+  const out = new Uint8Array(64 * 64 * 4)
+  out.set(src)
+  const at = (x, y) => (y * 64 + x) * 4
   for (const [x, y, dx, dy, w, h] of legacySkinCopies) {
-    ctx.save()
-    ctx.translate(x + dx + w, y + dy)
-    ctx.scale(-1, 1)
-    ctx.drawImage(image, x, y, w, h, 0, 0, w, h)
-    ctx.restore()
+    for (let j = 0; j < h; j++) {
+      for (let i = 0; i < w; i++) {
+        out.set(src.subarray(at(x + i, y + j), at(x + i, y + j) + 4), at(x + dx + w - 1 - i, y + dy + j))
+      }
+    }
   }
-  clearUnusedHat(ctx)
-  return new THREE.CanvasTexture(canvas)
+  let opaque = true
+  for (let y = 0; y < 32 && opaque; y++) for (let x = 32; x < 64; x++) if (out[at(x, y) + 3] < 128) { opaque = false; break }
+  if (opaque) for (let y = 0; y < 16; y++) for (let x = 32; x < 64; x++) out[at(x, y) + 3] = 0
+  const upgraded = new THREE.DataTexture(out, 64, 64, THREE.RGBAFormat)
+  upgraded.needsUpdate = true
+  return upgraded
 }
 
 function getMesh (texture, jsonModel, override) {

--- a/viewer/lib/entity/Entity.js
+++ b/viewer/lib/entity/Entity.js
@@ -128,7 +128,17 @@ function addCube (attr, boneId, bone, cube, texWidth = 64, texHeight = 64) {
   }
 }
 
-function getMesh (texture, jsonModel) {
+function applyTexture (material, texture) {
+  texture.magFilter = THREE.NearestFilter
+  texture.minFilter = THREE.NearestFilter
+  texture.flipY = false
+  texture.wrapS = THREE.RepeatWrapping
+  texture.wrapT = THREE.RepeatWrapping
+  material.map = texture
+  material.needsUpdate = true
+}
+
+function getMesh (texture, jsonModel, skin) {
   const bones = {}
 
   const geoData = {
@@ -195,19 +205,15 @@ function getMesh (texture, jsonModel) {
   mesh.scale.set(1 / 16, 1 / 16, 1 / 16)
 
   loadTexture(texture, texture => {
-    texture.magFilter = THREE.NearestFilter
-    texture.minFilter = THREE.NearestFilter
-    texture.flipY = false
-    texture.wrapS = THREE.RepeatWrapping
-    texture.wrapT = THREE.RepeatWrapping
-    material.map = texture
+    applyTexture(material, texture)
+    if (skin) loadTexture(skin, texture => applyTexture(material, texture))
   })
 
   return mesh
 }
 
 class Entity {
-  constructor (version, type, scene) {
+  constructor (version, type, scene, skin) {
     const e = entities[type]
     if (!e) throw new Error(`Unknown entity ${type}`)
 
@@ -216,7 +222,7 @@ class Entity {
       const texture = e.textures[name]
       if (!texture) continue
       // console.log(JSON.stringify(jsonModel, null, 2))
-      const mesh = getMesh(texture.replace('textures', 'textures/' + version) + '.png', jsonModel)
+      const mesh = getMesh(texture.replace('textures', 'textures/' + version) + '.png', jsonModel, skin)
       /* const skeletonHelper = new THREE.SkeletonHelper( mesh )
       skeletonHelper.material.linewidth = 2
       scene.add( skeletonHelper ) */

--- a/viewer/lib/entity/Entity.js
+++ b/viewer/lib/entity/Entity.js
@@ -234,13 +234,18 @@ function getMesh (texture, jsonModel, override) {
   mesh.bind(skeleton)
   mesh.scale.set(1 / 16, 1 / 16, 1 / 16)
 
-  if (texture) {
-    loadTexture(texture, texture => {
-      applyTexture(material, texture)
-      if (override) loadTexture(override, texture => applyTexture(material, upgradeLegacySkin(texture)))
-    })
-  } else {
-    loadTexture(override, texture => applyTexture(material, texture))
+  // Textures load the first time the mesh is drawn, so an entity the camera
+  // never sees (a player across the server) costs no fetch.
+  mesh.onBeforeRender = () => {
+    mesh.onBeforeRender = () => {}
+    if (texture) {
+      loadTexture(texture, texture => {
+        applyTexture(material, texture)
+        if (override) loadTexture(override, texture => applyTexture(material, upgradeLegacySkin(texture)))
+      })
+    } else {
+      loadTexture(override, texture => applyTexture(material, texture))
+    }
   }
 
   return mesh

--- a/viewer/lib/entity/Entity.js
+++ b/viewer/lib/entity/Entity.js
@@ -138,7 +138,7 @@ function applyTexture (material, texture) {
   material.needsUpdate = true
 }
 
-function getMesh (texture, jsonModel, skin) {
+function getMesh (texture, jsonModel, override) {
   const bones = {}
 
   const geoData = {
@@ -204,25 +204,29 @@ function getMesh (texture, jsonModel, skin) {
   mesh.bind(skeleton)
   mesh.scale.set(1 / 16, 1 / 16, 1 / 16)
 
-  loadTexture(texture, texture => {
-    applyTexture(material, texture)
-    if (skin) loadTexture(skin, texture => applyTexture(material, texture))
-  })
+  if (texture) {
+    loadTexture(texture, texture => {
+      applyTexture(material, texture)
+      if (override) loadTexture(override, texture => applyTexture(material, texture))
+    })
+  } else {
+    loadTexture(override, texture => applyTexture(material, texture))
+  }
 
   return mesh
 }
 
 class Entity {
-  constructor (version, type, scene, skin) {
+  constructor (version, type, scene, textures = {}) {
     const e = entities[type]
     if (!e) throw new Error(`Unknown entity ${type}`)
 
     this.mesh = new THREE.Object3D()
     for (const [name, jsonModel] of Object.entries(e.geometry)) {
       const texture = e.textures[name]
-      if (!texture) continue
+      if (!texture && !textures[name]) continue
       // console.log(JSON.stringify(jsonModel, null, 2))
-      const mesh = getMesh(texture.replace('textures', 'textures/' + version) + '.png', jsonModel, skin)
+      const mesh = getMesh(texture && texture.replace('textures', 'textures/' + version) + '.png', jsonModel, textures[name])
       /* const skeletonHelper = new THREE.SkeletonHelper( mesh )
       skeletonHelper.material.linewidth = 2
       scene.add( skeletonHelper ) */

--- a/viewer/lib/entity/Entity.js
+++ b/viewer/lib/entity/Entity.js
@@ -2,6 +2,7 @@
 
 const entities = require('./entities.json')
 const { loadTexture } = globalThis.isElectron ? require('../utils.electron.js') : require('../utils')
+const { createCanvas } = require('canvas')
 
 const elemFaces = {
   up: {
@@ -138,6 +139,29 @@ function applyTexture (material, texture) {
   material.needsUpdate = true
 }
 
+// Same rects as vanilla's SkinTextureDownloader.processLegacySkin: the left limbs are mirrored copies of the right ones.
+const legacySkinCopies = [
+  [4, 16, 16, 32, 4, 4], [8, 16, 16, 32, 4, 4], [0, 20, 24, 32, 4, 12], [4, 20, 16, 32, 4, 12], [8, 20, 8, 32, 4, 12], [12, 20, 16, 32, 4, 12],
+  [44, 16, -8, 32, 4, 4], [48, 16, -8, 32, 4, 4], [40, 20, 0, 32, 4, 12], [44, 20, -8, 32, 4, 12], [48, 20, -16, 32, 4, 12], [52, 20, -8, 32, 4, 12]
+]
+
+// Skins predating 1.8 are 64x32; the player geometry samples a 64x64 sheet. Capes are 64x32 by design and never pass through here.
+function upgradeLegacySkin (texture) {
+  const image = texture.image
+  if (image.width !== 64 || image.height !== 32) return texture
+  const canvas = createCanvas(64, 64)
+  const ctx = canvas.getContext('2d')
+  ctx.drawImage(image, 0, 0)
+  for (const [x, y, dx, dy, w, h] of legacySkinCopies) {
+    ctx.save()
+    ctx.translate(x + dx + w, y + dy)
+    ctx.scale(-1, 1)
+    ctx.drawImage(image, x, y, w, h, 0, 0, w, h)
+    ctx.restore()
+  }
+  return new THREE.CanvasTexture(canvas)
+}
+
 function getMesh (texture, jsonModel, override) {
   const bones = {}
 
@@ -207,7 +231,7 @@ function getMesh (texture, jsonModel, override) {
   if (texture) {
     loadTexture(texture, texture => {
       applyTexture(material, texture)
-      if (override) loadTexture(override, texture => applyTexture(material, texture))
+      if (override) loadTexture(override, texture => applyTexture(material, upgradeLegacySkin(texture)))
     })
   } else {
     loadTexture(override, texture => applyTexture(material, texture))

--- a/viewer/lib/entity/Entity.js
+++ b/viewer/lib/entity/Entity.js
@@ -26,36 +26,36 @@ const elemFaces = {
     u1: [2, 0, 1],
     v1: [0, 0, 1],
     corners: [
-      [1, 0, 1, 0, 0],
-      [0, 0, 1, 1, 0],
-      [1, 0, 0, 0, 1],
-      [0, 0, 0, 1, 1]
+      [1, 0, 1, 1, 0],
+      [0, 0, 1, 0, 0],
+      [1, 0, 0, 1, 1],
+      [0, 0, 0, 0, 1]
     ]
   },
   east: {
     dir: [1, 0, 0],
-    u0: [0, 0, 0],
-    v0: [0, 0, 1],
-    u1: [0, 0, 1],
-    v1: [0, 1, 1],
-    corners: [
-      [1, 1, 1, 0, 0],
-      [1, 0, 1, 0, 1],
-      [1, 1, 0, 1, 0],
-      [1, 0, 0, 1, 1]
-    ]
-  },
-  west: {
-    dir: [-1, 0, 0],
     u0: [1, 0, 1],
     v0: [0, 0, 1],
     u1: [1, 0, 2],
     v1: [0, 1, 1],
     corners: [
-      [0, 1, 0, 0, 0],
-      [0, 0, 0, 0, 1],
-      [0, 1, 1, 1, 0],
-      [0, 0, 1, 1, 1]
+      [1, 1, 1, 1, 0],
+      [1, 0, 1, 1, 1],
+      [1, 1, 0, 0, 0],
+      [1, 0, 0, 0, 1]
+    ]
+  },
+  west: {
+    dir: [-1, 0, 0],
+    u0: [0, 0, 0],
+    v0: [0, 0, 1],
+    u1: [0, 0, 1],
+    v1: [0, 1, 1],
+    corners: [
+      [0, 1, 0, 1, 0],
+      [0, 0, 0, 1, 1],
+      [0, 1, 1, 0, 0],
+      [0, 0, 1, 0, 1]
     ]
   },
   north: {
@@ -65,10 +65,10 @@ const elemFaces = {
     u1: [1, 0, 1],
     v1: [0, 1, 1],
     corners: [
-      [1, 0, 0, 0, 1],
-      [0, 0, 0, 1, 1],
-      [1, 1, 0, 0, 0],
-      [0, 1, 0, 1, 0]
+      [1, 0, 0, 1, 1],
+      [0, 0, 0, 0, 1],
+      [1, 1, 0, 1, 0],
+      [0, 1, 0, 0, 0]
     ]
   },
   south: {
@@ -78,10 +78,10 @@ const elemFaces = {
     u1: [2, 0, 2],
     v1: [0, 1, 1],
     corners: [
-      [0, 0, 1, 0, 1],
-      [1, 0, 1, 1, 1],
-      [0, 1, 1, 0, 0],
-      [1, 1, 1, 1, 0]
+      [0, 0, 1, 1, 1],
+      [1, 0, 1, 0, 1],
+      [0, 1, 1, 1, 0],
+      [1, 1, 1, 0, 0]
     ]
   }
 }
@@ -245,7 +245,10 @@ function getMesh (texture, jsonModel, override) {
   const mesh = new THREE.SkinnedMesh(geometry, material)
   mesh.add(...rootBones)
   mesh.bind(skeleton)
-  mesh.scale.set(1 / 16, 1 / 16, 1 / 16)
+  // Model space is x-mirrored relative to the world (Bedrock geometry, same as Java's model
+  // space, which vanilla draws under a (-1, -1, 1) scale): the left arm sits at +x. Flip it
+  // so the player's left limbs end up on their left; the face UVs below are laid out for this.
+  mesh.scale.set(-1 / 16, 1 / 16, 1 / 16)
 
   // Textures load the first time the mesh is drawn, so an entity the camera
   // never sees (a player across the server) costs no fetch.

--- a/viewer/lib/entity/Entity.js
+++ b/viewer/lib/entity/Entity.js
@@ -154,31 +154,37 @@ function texturePixels (image) {
   return ctx.getImageData(0, 0, image.width, image.height).data
 }
 
-// Skins predating 1.8 are 64x32; the player geometry samples a 64x64 sheet. Same steps as
-// vanilla's HttpTexture.processLegacySkin: the left limbs are mirrored copies of the right
-// ones, and an overlay block with no transparency at all was never used as a hat, so its
-// hat rows are dropped (the arm and torso rows below are base texture and stay). Capes are
+// Same steps as vanilla's HttpTexture.processLegacySkin. Skins predating 1.8 are 64x32 and
+// the player geometry samples a 64x64 sheet: the left limbs become mirrored copies of the
+// right ones, and an overlay block with no transparency at all was never used as a hat, so
+// its hat rows are dropped. Every skin then gets its base layers forced opaque (head, body
+// row, lower limbs), which is what makes the second layer the only see-through one. Capes are
 // 64x32 by design and never pass through here.
-function upgradeLegacySkin (texture) {
+function prepareSkin (texture) {
   const image = texture.image
-  if (image.width !== 64 || image.height !== 32) return texture
+  if (image.width !== 64 || (image.height !== 32 && image.height !== 64)) return texture
   const src = texturePixels(image)
   const out = new Uint8Array(64 * 64 * 4)
   out.set(src)
   const at = (x, y) => (y * 64 + x) * 4
-  for (const [x, y, dx, dy, w, h] of legacySkinCopies) {
-    for (let j = 0; j < h; j++) {
-      for (let i = 0; i < w; i++) {
-        out.set(src.subarray(at(x + i, y + j), at(x + i, y + j) + 4), at(x + dx + w - 1 - i, y + dy + j))
+  if (image.height === 32) {
+    for (const [x, y, dx, dy, w, h] of legacySkinCopies) {
+      for (let j = 0; j < h; j++) {
+        for (let i = 0; i < w; i++) {
+          out.set(src.subarray(at(x + i, y + j), at(x + i, y + j) + 4), at(x + dx + w - 1 - i, y + dy + j))
+        }
       }
     }
+    let opaque = true
+    for (let y = 0; y < 32 && opaque; y++) for (let x = 32; x < 64; x++) if (out[at(x, y) + 3] < 128) { opaque = false; break }
+    if (opaque) for (let y = 0; y < 16; y++) for (let x = 32; x < 64; x++) out[at(x, y) + 3] = 0
   }
-  let opaque = true
-  for (let y = 0; y < 32 && opaque; y++) for (let x = 32; x < 64; x++) if (out[at(x, y) + 3] < 128) { opaque = false; break }
-  if (opaque) for (let y = 0; y < 16; y++) for (let x = 32; x < 64; x++) out[at(x, y) + 3] = 0
-  const upgraded = new THREE.DataTexture(out, 64, 64, THREE.RGBAFormat)
-  upgraded.needsUpdate = true
-  return upgraded
+  for (const [x0, y0, x1, y1] of [[0, 0, 32, 16], [0, 16, 64, 32], [16, 48, 48, 64]]) {
+    for (let y = y0; y < y1; y++) for (let x = x0; x < x1; x++) out[at(x, y) + 3] = 255
+  }
+  const prepared = new THREE.DataTexture(out, 64, 64, THREE.RGBAFormat)
+  prepared.needsUpdate = true
+  return prepared
 }
 
 function getMesh (texture, jsonModel, override) {
@@ -257,7 +263,7 @@ function getMesh (texture, jsonModel, override) {
     if (texture) {
       loadTexture(texture, texture => {
         applyTexture(material, texture)
-        if (override) loadTexture(override, texture => applyTexture(material, upgradeLegacySkin(texture)))
+        if (override) loadTexture(override, texture => applyTexture(material, prepareSkin(texture)))
       })
     } else {
       loadTexture(override, texture => applyTexture(material, texture))

--- a/viewer/lib/entity/entities.json
+++ b/viewer/lib/entity/entities.json
@@ -11352,8 +11352,8 @@
             "name": "cape",
             "parent": "body",
             "pivot": [0, 24, 3],
-            "bind_pose_rotation": [0, 180, 0],
-            "rotation": [0, 180, 0],
+            "bind_pose_rotation": [6, 180, 0],
+            "rotation": [6, 180, 0],
             "cubes": [{"origin": [-5, 8, 3], "size": [10, 16, 1], "uv": [0, 0]}]
           }
         ]
@@ -12283,18 +12283,18 @@
           {
             "name": "leftArm",
             "parent": "body",
-            "pivot": [5, 22, 0],
+            "pivot": [5, 21.5, 0],
             "cubes": [
-              {"origin": [4, 12, -2], "size": [3, 12, 4], "uv": [32, 48]}
+              {"origin": [4, 11.5, -2], "size": [3, 12, 4], "uv": [32, 48]}
             ]
           },
           {
             "name": "leftSleeve",
             "parent": "leftArm",
-            "pivot": [5, 22, 0],
+            "pivot": [5, 21.5, 0],
             "cubes": [
               {
-                "origin": [4, 12, -2],
+                "origin": [4, 11.5, -2],
                 "size": [3, 12, 4],
                 "uv": [48, 48],
                 "inflate": 0.25
@@ -12305,18 +12305,18 @@
           {
             "name": "rightArm",
             "parent": "body",
-            "pivot": [-5, 22, 0],
+            "pivot": [-5, 21.5, 0],
             "cubes": [
-              {"origin": [-7, 12, -2], "size": [3, 12, 4], "uv": [40, 16]}
+              {"origin": [-7, 11.5, -2], "size": [3, 12, 4], "uv": [40, 16]}
             ]
           },
           {
             "name": "rightSleeve",
             "parent": "rightArm",
-            "pivot": [-5, 22, 0],
+            "pivot": [-5, 21.5, 0],
             "cubes": [
               {
-                "origin": [-7, 12, -2],
+                "origin": [-7, 11.5, -2],
                 "size": [3, 12, 4],
                 "uv": [40, 32],
                 "inflate": 0.25
@@ -12402,8 +12402,8 @@
             "name": "cape",
             "parent": "body",
             "pivot": [0, 24, 3],
-            "bind_pose_rotation": [0, 180, 0],
-            "rotation": [0, 180, 0],
+            "bind_pose_rotation": [6, 180, 0],
+            "rotation": [6, 180, 0],
             "cubes": [{"origin": [-5, 8, 3], "size": [10, 16, 1], "uv": [0, 0]}]
           }
         ]

--- a/viewer/lib/entity/entities.json
+++ b/viewer/lib/entity/entities.json
@@ -12234,6 +12234,1056 @@
       }
     }
   },
+  "player_slim": {
+    "identifier": "minecraft:player_slim",
+    "materials": {
+      "default": "entity_alphatest",
+      "cape": "entity_alphatest",
+      "animated": "player_animated"
+    },
+    "textures": {
+      "default": "textures/entity/alex"
+    },
+    "geometry": {
+      "default": {
+        "visible_bounds_width": 1,
+        "visible_bounds_height": 2,
+        "visible_bounds_offset": [0, 1, 0],
+        "bones": [
+          {"name": "root", "pivot": [0, 0, 0]},
+          {
+            "name": "body",
+            "parent": "waist",
+            "pivot": [0, 24, 0],
+            "cubes": [
+              {"origin": [-4, 12, -2], "size": [8, 12, 4], "uv": [16, 16]}
+            ]
+          },
+          {"name": "waist", "parent": "root", "pivot": [0, 12, 0]},
+          {
+            "name": "head",
+            "parent": "body",
+            "pivot": [0, 24, 0],
+            "cubes": [{"origin": [-4, 24, -4], "size": [8, 8, 8], "uv": [0, 0]}]
+          },
+          {"name": "cape", "pivot": [0, 24, 3], "parent": "body"},
+          {
+            "name": "hat",
+            "parent": "head",
+            "pivot": [0, 24, 0],
+            "cubes": [
+              {
+                "origin": [-4, 24, -4],
+                "size": [8, 8, 8],
+                "uv": [32, 0],
+                "inflate": 0.5
+              }
+            ]
+          },
+          {
+            "name": "leftArm",
+            "parent": "body",
+            "pivot": [5, 22, 0],
+            "cubes": [
+              {"origin": [4, 12, -2], "size": [3, 12, 4], "uv": [32, 48]}
+            ]
+          },
+          {
+            "name": "leftSleeve",
+            "parent": "leftArm",
+            "pivot": [5, 22, 0],
+            "cubes": [
+              {
+                "origin": [4, 12, -2],
+                "size": [3, 12, 4],
+                "uv": [48, 48],
+                "inflate": 0.25
+              }
+            ]
+          },
+          {"name": "leftItem", "pivot": [6, 15, 1], "parent": "leftArm"},
+          {
+            "name": "rightArm",
+            "parent": "body",
+            "pivot": [-5, 22, 0],
+            "cubes": [
+              {"origin": [-7, 12, -2], "size": [3, 12, 4], "uv": [40, 16]}
+            ]
+          },
+          {
+            "name": "rightSleeve",
+            "parent": "rightArm",
+            "pivot": [-5, 22, 0],
+            "cubes": [
+              {
+                "origin": [-7, 12, -2],
+                "size": [3, 12, 4],
+                "uv": [40, 32],
+                "inflate": 0.25
+              }
+            ]
+          },
+          {
+            "name": "rightItem",
+            "pivot": [-6, 15, 1],
+            "locators": {"lead_hold": [-6, 15, 1]},
+            "parent": "rightArm"
+          },
+          {
+            "name": "leftLeg",
+            "parent": "root",
+            "pivot": [1.9, 12, 0],
+            "cubes": [
+              {"origin": [-0.1, 0, -2], "size": [4, 12, 4], "uv": [16, 48]}
+            ]
+          },
+          {
+            "name": "leftPants",
+            "parent": "leftLeg",
+            "pivot": [1.9, 12, 0],
+            "cubes": [
+              {
+                "origin": [-0.1, 0, -2],
+                "size": [4, 12, 4],
+                "uv": [0, 48],
+                "inflate": 0.25
+              }
+            ]
+          },
+          {
+            "name": "rightLeg",
+            "parent": "root",
+            "pivot": [-1.9, 12, 0],
+            "cubes": [
+              {"origin": [-3.9, 0, -2], "size": [4, 12, 4], "uv": [0, 16]}
+            ]
+          },
+          {
+            "name": "rightPants",
+            "parent": "rightLeg",
+            "pivot": [-1.9, 12, 0],
+            "cubes": [
+              {
+                "origin": [-3.9, 0, -2],
+                "size": [4, 12, 4],
+                "uv": [0, 32],
+                "inflate": 0.25
+              }
+            ]
+          },
+          {
+            "name": "jacket",
+            "parent": "body",
+            "pivot": [0, 24, 0],
+            "cubes": [
+              {
+                "origin": [-4, 12, -2],
+                "size": [8, 12, 4],
+                "uv": [16, 32],
+                "inflate": 0.25
+              }
+            ]
+          }
+        ]
+      },
+      "cape": {
+        "texturewidth": 64,
+        "textureheight": 32,
+        "bones": [
+          {"name": "root", "pivot": [0, 0, 0]},
+          {"name": "body", "pivot": [0, 24, 0], "parent": "waist"},
+          {
+            "name": "waist",
+            "parent": "root",
+            "neverRender": true,
+            "pivot": [0, 12, 0]
+          },
+          {
+            "name": "cape",
+            "parent": "body",
+            "pivot": [0, 24, 3],
+            "bind_pose_rotation": [0, 180, 0],
+            "rotation": [0, 180, 0],
+            "cubes": [{"origin": [-5, 8, 3], "size": [10, 16, 1], "uv": [0, 0]}]
+          }
+        ]
+      }
+    },
+    "scripts": {
+      "scale": "0.9375",
+      "initialize": [
+        "variable.is_holding_right = 0.0;",
+        "variable.is_blinking = 0.0;",
+        "variable.last_blink_time = 0.0;",
+        "variable.hand_bob = 0.0;"
+      ],
+      "pre_animation": [
+        "variable.helmet_layer_visible = 1.0;",
+        "variable.leg_layer_visible = 1.0;",
+        "variable.boot_layer_visible = 1.0;",
+        "variable.chest_layer_visible = 1.0;",
+        "variable.attack_body_rot_y = Math.sin(360*Math.sqrt(variable.attack_time)) * 5.0;",
+        "variable.tcos0 = (math.cos(query.modified_distance_moved * 38.17) * query.modified_move_speed / variable.gliding_speed_value) * 57.3;",
+        "variable.first_person_rotation_factor = math.sin((1 - variable.attack_time) * 180.0);",
+        "variable.hand_bob = query.life_time < 0.01 ? 0.0 : variable.hand_bob + ((query.is_on_ground && query.is_alive ? math.clamp(math.sqrt(math.pow(query.position_delta(0), 2.0) + math.pow(query.position_delta(2), 2.0)), 0.0, 0.1) : 0.0) - variable.hand_bob) * 0.02;",
+        "variable.map_angle = math.clamp(1 - variable.player_x_rotation / 45.1, 0.0, 1.0);",
+        "variable.item_use_normalized = query.main_hand_item_use_duration / query.main_hand_item_max_duration;"
+      ],
+      "animate": ["root"]
+    },
+    "animations": {
+      "humanoid_base_pose": {
+        "loop": true,
+        "bones": {"waist": {"rotation": [0, 0, 0]}}
+      },
+      "look_at_target_ui": {
+        "loop": true,
+        "bones": {
+          "head": {
+            "rotation": [
+              "query.target_x_rotation",
+              "query.target_y_rotation",
+              0
+            ]
+          }
+        }
+      },
+      "look_at_target_default": {
+        "loop": true,
+        "bones": {
+          "head": {
+            "relative_to": {"rotation": "entity"},
+            "rotation": [
+              "query.target_x_rotation",
+              "query.target_y_rotation",
+              0
+            ]
+          }
+        }
+      },
+      "look_at_target_gliding": {
+        "loop": true,
+        "bones": {"head": {"rotation": [-45, "query.target_y_rotation", 0]}}
+      },
+      "look_at_target_swimming": {
+        "loop": true,
+        "bones": {
+          "head": {
+            "rotation": [
+              "math.lerp(query.target_x_rotation, -45.0, variable.swim_amount)",
+              "query.target_y_rotation",
+              0
+            ]
+          }
+        }
+      },
+      "look_at_target_inverted": {
+        "loop": true,
+        "bones": {
+          "head": {
+            "rotation": [
+              "-query.target_x_rotation",
+              "-query.target_y_rotation",
+              0
+            ]
+          }
+        }
+      },
+      "cape": {
+        "loop": true,
+        "bones": {
+          "cape": {
+            "position": [
+              0,
+              "query.get_root_locator_offset('armor_offset.default_neck', 1)",
+              0
+            ],
+            "rotation": [
+              "math.lerp(0.0, -126.0, query.cape_flap_amount) - 6.0",
+              0,
+              0
+            ]
+          }
+        }
+      },
+      "move.arms": {
+        "loop": true,
+        "bones": {
+          "leftarm": {"rotation": ["variable.tcos0", 0, 0]},
+          "rightarm": {"rotation": ["-variable.tcos0", 0, 0]}
+        }
+      },
+      "move.legs": {
+        "loop": true,
+        "bones": {
+          "leftleg": {"rotation": ["variable.tcos0 * -1.4", 0, 0]},
+          "rightleg": {"rotation": ["variable.tcos0 * 1.4", 0, 0]}
+        }
+      },
+      "swimming": {
+        "animation_length": 1.3,
+        "loop": true,
+        "override_previous_animation": true,
+        "bones": {
+          "leftarm": {
+            "rotation": {
+              "0": [0, 180, 180],
+              "0.7": [0, 180, 287.2],
+              "1.1": [90, 180, 180],
+              "1.3": [0, 180, 180]
+            }
+          },
+          "rightarm": {
+            "rotation": {
+              "0": [0, 180, -180],
+              "0.7": [0, 180, -287.2],
+              "1.1": [90, 180, -180],
+              "1.3": [0, 180, -180]
+            }
+          },
+          "root": {
+            "position": [
+              0,
+              "(math.sin(query.target_x_rotation) * 24.0 + 3.0) * variable.swim_amount",
+              "(math.cos(query.target_x_rotation) * 24.0 + 9.0) * variable.swim_amount"
+            ],
+            "rotation": [
+              "variable.swim_amount * (90 + query.target_x_rotation)",
+              0,
+              0
+            ]
+          }
+        }
+      },
+      "swimming.legs": {
+        "loop": true,
+        "override_previous_animation": true,
+        "bones": {
+          "leftleg": {
+            "rotation": [
+              "math.lerp(0.0, math.cos(query.life_time * 390.0 + 180.0) * 17.2, variable.swim_amount)",
+              0,
+              0
+            ]
+          },
+          "rightleg": {
+            "rotation": [
+              "math.lerp(0.0, math.cos(query.life_time * 390.0) * 17.2, variable.swim_amount)",
+              0,
+              0
+            ]
+          }
+        }
+      },
+      "riding.arms": {
+        "loop": true,
+        "bones": {
+          "leftarm": {"rotation": [-36, 0, 0]},
+          "rightarm": {"rotation": [-36, 0, 0]}
+        }
+      },
+      "riding.legs": {
+        "loop": true,
+        "bones": {
+          "leftleg": {"rotation": ["-72.0 - this", "-18.0 - this", "-this"]},
+          "rightleg": {"rotation": ["-72.0 - this", "18.0 - this", "-this"]}
+        }
+      },
+      "holding": {
+        "loop": true,
+        "bones": {
+          "leftarm": {
+            "rotation": [
+              "variable.is_holding_left ? (-this * 0.5 - 18.0) : 0.0",
+              0,
+              0
+            ]
+          },
+          "rightarm": {
+            "rotation": [
+              "variable.is_holding_right ? (-this * 0.5 - 18.0) : 0.0",
+              0,
+              0
+            ]
+          }
+        }
+      },
+      "brandish_spear": {
+        "loop": true,
+        "bones": {
+          "rightarm": {
+            "rotation": [
+              "this * -0.5 - 157.5 - 22.5 * variable.charge_amount",
+              "-this",
+              0
+            ]
+          }
+        }
+      },
+      "charging": {
+        "loop": true,
+        "bones": {
+          "rightarm": {
+            "rotation": ["22.5 * variable.charge_amount - this", "-this", 0]
+          }
+        }
+      },
+      "attack.positions": {
+        "loop": true,
+        "bones": {"head": {"rotation": [0, 0, 0]}}
+      },
+      "attack.rotations": {
+        "loop": true,
+        "bones": {
+          "body": {"rotation": [0, "variable.attack_body_rot_y", 0]},
+          "leftarm": {
+            "rotation": [
+              "-(math.sin((1 - math.pow((1 - variable.attack_time), 4)) * 180) * 1.2 + math.sin(variable.attack_time * 180)) * 10.0",
+              0,
+              0
+            ]
+          },
+          "rightarm": {
+            "rotation": [
+              "-(math.sin((1 - math.pow((1 - variable.attack_time), 4)) * 180) * 1.2 + math.sin(variable.attack_time * 180)) * 30.0",
+              "-(math.sin((1 - math.pow((1 - variable.attack_time), 4)) * 180) ? (-90.0 * math.sin((1 - math.pow((1 - variable.attack_time), 4)) * 180)) + 30.0 : 0.0)",
+              0
+            ]
+          }
+        }
+      },
+      "sneaking": {
+        "loop": true,
+        "bones": {
+          "body": {"position": [0, -2, 0]},
+          "head": {"position": [0, -1, 0]},
+          "leftarm": {"rotation": [-5.7, 0, 0]},
+          "leftleg": {"rotation": [-28, 0, 0]},
+          "rightarm": {"rotation": [-5.7, 0, 0]},
+          "rightleg": {"rotation": [-28, 0, 0]},
+          "root": {"position": [0, 1.25, 9], "rotation": ["28.0 - this", 0, 0]}
+        }
+      },
+      "bob": {
+        "loop": true,
+        "bones": {
+          "leftarm": {
+            "rotation": [
+              0,
+              0,
+              "-((math.cos(query.life_time * 103.2) * 2.865) + 2.865)"
+            ]
+          },
+          "rightarm": {
+            "rotation": [
+              0,
+              0,
+              "(math.cos(query.life_time * 103.2) * 2.865) + 2.865"
+            ]
+          }
+        }
+      },
+      "damage_nearby_mobs": {
+        "loop": true,
+        "bones": {
+          "leftarm": {"rotation": ["-45.0-this", "-this", "-this"]},
+          "leftleg": {"rotation": ["45.0-this", "-this", "-this"]},
+          "rightarm": {"rotation": ["45.0-this", "-this", "-this"]},
+          "rightleg": {"rotation": ["-45.0-this", "-this", "-this"]}
+        }
+      },
+      "fishing_rod": {
+        "loop": true,
+        "bones": {"rightarm": {"rotation": [" -19.0 - this", "-this", "-this"]}}
+      },
+      "use_item_progress": {
+        "loop": true,
+        "bones": {
+          "rightarm": {
+            "rotation": [
+              "variable.use_item_startup_progress * -60.0 + variable.use_item_interval_progress * 11.25",
+              "variable.use_item_startup_progress * -22.5 + variable.use_item_interval_progress * 11.25",
+              "variable.use_item_startup_progress * -5.625 + variable.use_item_interval_progress * 11.25"
+            ]
+          }
+        }
+      },
+      "skeleton_attack": {
+        "loop": true,
+        "bones": {
+          "leftarm": {
+            "rotation": [
+              "-68.75 * math.sin(variable.attack_time * 180.0) + 22.92 * (math.sin((1.0 - (1.0 - variable.attack_time) * (1.0 - variable.attack_time)) * 180.0))",
+              "5.73 - math.sin(variable.attack_time * 180.0) * 34.38 - this",
+              "-this"
+            ]
+          },
+          "rightarm": {
+            "rotation": [
+              "-68.75 * math.sin(variable.attack_time * 180.0) + 22.92 * (math.sin((1.0 - (1.0 - variable.attack_time) * (1.0 - variable.attack_time)) * 180.0))",
+              "-5.73 + math.sin(variable.attack_time * 180.0) * 34.38 - this",
+              "-this"
+            ]
+          }
+        }
+      },
+      "sleeping": {
+        "loop": true,
+        "override_previous_animation": true,
+        "bones": {
+          "head": {"rotation": ["30.0 - this", "-this", "-this"]},
+          "root": {
+            "position": [
+              "24.0 * math.cos(query.body_y_rotation) * math.cos(query.sleep_rotation) - 24.0 * math.sin(query.body_y_rotation) * math.sin(query.sleep_rotation)",
+              0,
+              "24.0 * math.cos(query.body_y_rotation) * math.sin(query.sleep_rotation) + 24.0 * math.sin(query.body_y_rotation) * math.cos(query.sleep_rotation)"
+            ],
+            "rotation": [
+              -90,
+              "270.0 - query.sleep_rotation - query.body_y_rotation",
+              0
+            ]
+          }
+        }
+      },
+      "first_person_base_pose": {
+        "loop": true,
+        "bones": {
+          "body": {
+            "rotation": [
+              "query.target_x_rotation",
+              "query.target_y_rotation",
+              0
+            ]
+          }
+        }
+      },
+      "first_person_empty_hand": {
+        "loop": true,
+        "bones": {
+          "rightarm": {
+            "position": [13.5, -10, 12],
+            "rotation": [
+              "95.0 + variable.is_using_vr * 7.5",
+              "-45.0 + variable.is_using_vr * 7.5",
+              "115.0 + variable.is_using_vr * -2.5"
+            ]
+          }
+        }
+      },
+      "first_person_swap_item": {
+        "loop": true,
+        "bones": {
+          "leftarm": {
+            "position": [
+              0,
+              "query.get_equipped_item_name('off_hand') == 'map' ? 0.0 : -10.0 * (1.0 - variable.player_arm_height)",
+              0
+            ]
+          },
+          "rightarm": {
+            "position": [0, "-10.0 * (1.0 - variable.player_arm_height)", 0]
+          }
+        }
+      },
+      "first_person_attack_rotation": {
+        "loop": true,
+        "bones": {
+          "rightarm": {
+            "position": [
+              "math.clamp(-15.5 * math.sin(variable.first_person_rotation_factor * variable.attack_time * 112.0), -7.0, 999.0) * math.sin(variable.first_person_rotation_factor * variable.attack_time * 112.0)",
+              "math.sin(variable.first_person_rotation_factor * (1.0 - variable.attack_time) * (1.0 - variable.attack_time) * 200.0) * 7.5 - variable.first_person_rotation_factor * variable.attack_time * 15.0 + variable.short_arm_offset_right",
+              "math.sin(variable.first_person_rotation_factor * variable.attack_time * 120.0) * 1.75"
+            ],
+            "rotation": [
+              "math.sin(variable.first_person_rotation_factor * (1.0 - variable.attack_time) * (1.0 - variable.attack_time) * 280.0) * -60.0",
+              "math.sin(variable.first_person_rotation_factor * (1.0 - variable.attack_time) * (1.0 - variable.attack_time) * 280.0) * 40.0",
+              "math.sin(variable.first_person_rotation_factor * (1.0 - variable.attack_time) * (1.0 - variable.attack_time) * 280.0) * 20.0"
+            ]
+          }
+        }
+      },
+      "first_person_vr_attack_rotation": {
+        "loop": true,
+        "bones": {
+          "rightarm": {
+            "position": [
+              "5.0 * math.sin(variable.first_person_rotation_factor * variable.attack_time * 112.0)",
+              "(math.sin(variable.first_person_rotation_factor * (1.0 - variable.attack_time) * (1.0 - variable.attack_time) * 200.0) - 0.8) * 8.75 + 5.0",
+              "math.sin(variable.first_person_rotation_factor * variable.attack_time * 120.0) * 15.0"
+            ],
+            "rotation": [
+              "30.7 * math.sin(variable.first_person_rotation_factor * variable.attack_time * -180.0 - 45.0) * 1.5",
+              0,
+              "21.8 * math.sin(variable.first_person_rotation_factor * variable.attack_time * 200.0 + 30.0) * 1.25"
+            ]
+          }
+        }
+      },
+      "first_person_map_hold": {
+        "loop": true,
+        "bones": {
+          "leftarm": {
+            "position": [
+              "-16.250 + variable.is_vertical_splitscreen * 7.0",
+              "-10.75 - variable.map_angle * 8.0 + variable.is_vertical_splitscreen * 0.6 - variable.short_arm_offset_left",
+              "9.0 - variable.map_angle * 8.0 + variable.short_arm_offset_left"
+            ],
+            "rotation": [40, -20, -155],
+            "scale": [1.15, 1.15, 1.15]
+          },
+          "rightarm": {
+            "position": [
+              "12.50 + variable.is_vertical_splitscreen * 1.75",
+              "-7.5 - variable.map_angle * 8.0 + variable.is_vertical_splitscreen * 0.5 - variable.short_arm_offset_right",
+              "5.25 - variable.map_angle * 8.0 + variable.short_arm_offset_right"
+            ],
+            "rotation": [77.5, 7.5, 160]
+          }
+        }
+      },
+      "first_person_map_hold_attack": {
+        "loop": true,
+        "bones": {
+          "leftarm": {
+            "position": [
+              "math.sin(variable.first_person_rotation_factor * variable.attack_time * 112.0) * -10.75",
+              "math.sin(variable.first_person_rotation_factor * (1.0 - variable.attack_time) * (1.0 - variable.attack_time) * 200.0) * 3.75 - variable.first_person_rotation_factor * variable.attack_time * 1.25 + variable.short_arm_offset_left",
+              "math.sin(variable.first_person_rotation_factor * variable.attack_time * 120.0) * 5.75"
+            ],
+            "rotation": [
+              "variable.map_angle * 90.0",
+              "-15.0 * math.sin(variable.first_person_rotation_factor * (1.0 - variable.attack_time) * -100.0)",
+              0
+            ]
+          },
+          "rightarm": {
+            "position": [
+              "math.sin(variable.first_person_rotation_factor * variable.attack_time * 112.0) * -6.25",
+              "math.sin(variable.first_person_rotation_factor * (1.0 - variable.attack_time) * (1.0 - variable.attack_time) * 200.0) * 1.75 + variable.short_arm_offset_right",
+              "math.sin(variable.first_person_rotation_factor * variable.attack_time * 120.0) * 5.25"
+            ],
+            "rotation": ["variable.map_angle * 90.0", 0, 0]
+          }
+        }
+      },
+      "first_person_map_hold_off_hand": {
+        "loop": true,
+        "bones": {
+          "leftarm": {
+            "position": [
+              "-14.50 + variable.is_horizontal_splitscreen * 2.0 + variable.is_vertical_splitscreen * 8.7",
+              "-8.250 + variable.short_arm_offset_left",
+              "11.50 + variable.is_horizontal_splitscreen * 0.5"
+            ],
+            "rotation": [195, 182.5, 2.5],
+            "scale": [0.75, 0.75, 0.75]
+          }
+        }
+      },
+      "first_person_map_hold_main_hand": {
+        "loop": true,
+        "bones": {
+          "rightarm": {
+            "position": [
+              "14.50 - variable.is_vertical_splitscreen * 0.75",
+              "-8.25 + variable.short_arm_offset_right + math.sin(variable.first_person_rotation_factor * (1.0 - variable.attack_time) * (1.0 - variable.attack_time) * 200.0) * 2.75 - variable.first_person_rotation_factor * variable.attack_time * 3.0 - variable.is_horizontal_splitscreen",
+              "11.5 + math.sin(variable.first_person_rotation_factor * variable.attack_time * 120.0) * 3.5 + variable.is_horizontal_splitscreen * 3.5"
+            ],
+            "rotation": [195, 182.5, -5],
+            "scale": [0.75, 0.75, 0.75]
+          }
+        }
+      },
+      "first_person_crossbow_equipped": {
+        "loop": true,
+        "override_previous_animation": true,
+        "bones": {
+          "leftarm": {
+            "position": [
+              "1.5 - variable.item_use_normalized * 3.5",
+              "-3.799999952316284 + variable.short_arm_offset_left",
+              "8.25 - (1 - variable.item_use_normalized)"
+            ],
+            "rotation": [165, -60, 45],
+            "scale": [0.4, 0.4, 0.4]
+          }
+        }
+      },
+      "third_person_crossbow_equipped": {
+        "loop": true,
+        "bones": {
+          "leftarm": {
+            "position": [0, 0, 0.5],
+            "rotation": [
+              "-this - 65.0 - (1.0 - variable.item_use_normalized) * 5.0",
+              "-this + (1.0 - variable.item_use_normalized) * 30.0",
+              "-this + 20.0 + (1.0 - variable.item_use_normalized) * 10.0"
+            ]
+          },
+          "rightarm": {
+            "rotation": ["- 60.0 - this", "- 45.0 - this", "- 2.5 - this"]
+          }
+        }
+      },
+      "third_person_bow_equipped": {
+        "loop": true,
+        "bones": {
+          "leftarm": {
+            "rotation": [
+              "-90.0 + query.target_x_rotation - query.is_sneaking * 15.0 - this",
+              "27.5 + query.target_y_rotation",
+              0
+            ]
+          },
+          "rightarm": {
+            "rotation": [
+              "-90.0 + query.target_x_rotation - query.is_sneaking * 15.0 - this",
+              "-5.0 + query.target_y_rotation",
+              0
+            ]
+          },
+          "rightitem": {"rotation": [0, -10, 0]}
+        }
+      },
+      "crossbow_hold": {
+        "loop": true,
+        "bones": {
+          "leftarm": {
+            "rotation": [
+              "query.is_swimming ? 0.0 : -93.0 + query.target_x_rotation - query.is_sneaking * 27.0 -this",
+              "query.is_swimming ? 0.0 : 42.0 + math.clamp(query.target_y_rotation, -45.0, 5.0) -this",
+              "query.is_sneaking * -15.0"
+            ]
+          },
+          "rightarm": {
+            "rotation": [
+              "query.is_swimming ? 0.0 : -93.0 + query.target_x_rotation - query.is_sneaking * 27.0 -this",
+              "query.is_swimming ? 0.0 : math.clamp(query.target_y_rotation, -60.0, 45.0) -this",
+              0
+            ]
+          }
+        }
+      },
+      "shield_block_main_hand": {
+        "loop": true,
+        "bones": {
+          "rightarm": {"rotation": [-20, -30, -25]},
+          "rightitem": {"position": [-1, -3, 0], "rotation": [0, -60, -45]}
+        }
+      },
+      "shield_block_off_hand": {
+        "loop": true,
+        "bones": {
+          "leftarm": {"rotation": [-20, 20, 20]},
+          "leftitem": {
+            "position": [
+              "1.0 + query.item_is_charged * 1.5",
+              "-3.0 + query.item_is_charged",
+              0
+            ],
+            "rotation": [
+              "query.item_is_charged * 30.0",
+              "70.0 - query.item_is_charged * 60.0",
+              "65.0 - query.item_is_charged * 15.0"
+            ]
+          }
+        }
+      }
+    },
+    "render_controllers": [
+      {"controller.render.player.first_person": "variable.is_first_person"},
+      {
+        "controller.render.player.third_person": "!variable.is_first_person && !variable.map_face_icon"
+      },
+      {"controller.render.player.map": "variable.map_face_icon"}
+    ],
+    "enable_attachables": true,
+    "animation_controllers": {
+      "root": {
+        "initial_state": "first_person",
+        "states": {
+          "first_person": {
+            "animations": [
+              "first_person_swap_item",
+              {
+                "first_person_attack_controller": "variable.attack_time > 0.0f && query.get_equipped_item_name != 'map'"
+              },
+              "first_person_base_pose",
+              {
+                "first_person_empty_hand": "query.get_equipped_item_name(0, 1) != 'map'"
+              },
+              {
+                "first_person_map_controller": "(query.get_equipped_item_name(0, 1) == 'map' || query.get_equipped_item_name('off_hand') == 'map')"
+              },
+              {
+                "first_person_crossbow_equipped": "query.get_equipped_item_name == 'crossbow' && (variable.item_use_normalized > 0 && variable.item_use_normalized < 1.0)"
+              }
+            ],
+            "transitions": [
+              {"paperdoll": "variable.is_paperdoll"},
+              {"map_player": "variable.map_face_icon"},
+              {"third_person": "!variable.is_first_person"}
+            ]
+          },
+          "map_player": {
+            "transitions": [
+              {"paperdoll": "variable.is_paperdoll"},
+              {"first_person": "variable.is_first_person"},
+              {
+                "third_person": "!variable.map_face_icon && !variable.is_first_person"
+              }
+            ]
+          },
+          "paperdoll": {
+            "animations": [
+              "humanoid_base_pose",
+              {"look_at_target_ui": "variable.should_look_at_target_ui"},
+              "move.arms",
+              "move.legs",
+              "cape"
+            ],
+            "transitions": [
+              {
+                "first_person": "!variable.is_paperdoll && variable.is_first_person"
+              },
+              {"map_player": "variable.map_face_icon"},
+              {
+                "third_person": "!variable.is_paperdoll && !variable.is_first_person"
+              }
+            ]
+          },
+          "third_person": {
+            "animations": [
+              "humanoid_base_pose",
+              {"look_at_target": "!query.is_sleeping && !query.is_emoting"},
+              "move.arms",
+              "move.legs",
+              "cape",
+              {"riding.arms": "query.is_riding"},
+              {"riding.legs": "query.is_riding"},
+              "holding",
+              {"brandish_spear": "variable.is_brandishing_spear"},
+              {"charging": "query.is_charging"},
+              {"sneaking": "query.is_sneaking && !query.is_sleeping"},
+              "bob",
+              {"damage_nearby_mobs": "variable.damage_nearby_mobs"},
+              {"swimming": "variable.swim_amount > 0.0"},
+              {"swimming.legs": "variable.swim_amount > 0.0"},
+              {
+                "use_item_progress": "( variable.use_item_interval_progress > 0.0 ) || ( variable.use_item_startup_progress > 0.0 ) && !variable.is_brandishing_spear"
+              },
+              {"fishing_rod": "query.get_equipped_item_name == 'fishing_rod'"},
+              {"sleeping": "query.is_sleeping && query.is_alive"},
+              {"attack.positions": "variable.attack_time >= 0.0"},
+              {"attack.rotations": "variable.attack_time >= 0.0"},
+              {
+                "shield_block_main_hand": "query.blocking && query.get_equipped_item_name('off_hand') != 'shield' && query.get_equipped_item_name == 'shield'"
+              },
+              {
+                "shield_block_off_hand": "query.blocking && query.get_equipped_item_name('off_hand') == 'shield' && !(variable.item_use_normalized > 0 && variable.item_use_normalized < 1.0)"
+              },
+              {
+                "crossbow_controller": "query.get_equipped_item_name == 'crossbow'"
+              },
+              {
+                "third_person_bow_equipped": "query.get_equipped_item_name == 'bow' && (variable.item_use_normalized > 0 && variable.item_use_normalized < 1.0)"
+              }
+            ],
+            "transitions": [
+              {"paperdoll": "variable.is_paperdoll"},
+              {"first_person": "variable.is_first_person"},
+              {"map_player": "variable.map_face_icon"}
+            ]
+          }
+        }
+      },
+      "base_controller": "controller.animation.player.base",
+      "hudplayer": {
+        "initial_state": "default",
+        "states": {
+          "default": {
+            "animations": [
+              "humanoid_base_pose",
+              {"look_at_target": "!query.is_sleeping && !query.is_emoting"},
+              "move.arms",
+              "move.legs",
+              "cape",
+              {"riding.arms": "query.is_riding"},
+              {"riding.legs": "query.is_riding"},
+              "holding",
+              {"brandish_spear": "variable.is_brandishing_spear"},
+              {"charging": "query.is_charging"},
+              {"sneaking": "query.is_sneaking && !query.is_sleeping"},
+              "bob",
+              {"damage_nearby_mobs": "variable.damage_nearby_mobs"},
+              {"swimming": "variable.swim_amount > 0.0"},
+              {"swimming.legs": "variable.swim_amount > 0.0"},
+              {
+                "use_item_progress": "( variable.use_item_interval_progress > 0.0 ) || ( variable.use_item_startup_progress > 0.0 ) && !variable.is_brandishing_spear"
+              },
+              {"sleeping": "query.is_sleeping && query.is_alive"},
+              {"attack.positions": "variable.attack_time >= 0.0"},
+              {"attack.rotations": "variable.attack_time >= 0.0"},
+              {
+                "shield_block_main_hand": "query.blocking && query.get_equipped_item_name('off_hand') != 'shield' && query.get_equipped_item_name == 'shield'"
+              },
+              {
+                "shield_block_off_hand": "query.blocking && query.get_equipped_item_name('off_hand') == 'shield' && !(variable.item_use_normalized > 0 && variable.item_use_normalized < 1.0)"
+              },
+              {
+                "crossbow_controller": "query.get_equipped_item_name == 'crossbow'"
+              },
+              {
+                "third_person_bow_equipped": "query.get_equipped_item_name == 'bow' && (variable.item_use_normalized > 0 && variable.item_use_normalized < 1.0)"
+              }
+            ]
+          }
+        }
+      },
+      "look_at_target": {
+        "initial_state": "default",
+        "states": {
+          "default": {
+            "animations": ["look_at_target_default"],
+            "transitions": [
+              {"gliding": "query.is_gliding"},
+              {"swimming": "query.is_swimming"}
+            ]
+          },
+          "gliding": {
+            "animations": ["look_at_target_gliding"],
+            "transitions": [
+              {"swimming": "query.is_swimming"},
+              {"default": "!query.is_gliding"}
+            ]
+          },
+          "swimming": {
+            "animations": ["look_at_target_swimming"],
+            "transitions": [
+              {"gliding": "query.is_gliding"},
+              {"default": "!query.is_swimming"}
+            ]
+          }
+        }
+      },
+      "first_person_attack_controller": {
+        "initial_state": "default",
+        "states": {
+          "default": {
+            "animations": ["first_person_attack_rotation"],
+            "transitions": [{"vr_attack": "variable.is_using_vr"}]
+          },
+          "vr_attack": {
+            "animations": ["first_person_vr_attack_rotation"],
+            "transitions": [{"default": "!variable.is_using_vr"}]
+          }
+        }
+      },
+      "first_person_map_controller": {
+        "initial_state": "default",
+        "states": {
+          "default": {
+            "transitions": [
+              {
+                "one_hand": "query.get_equipped_item_name('off_hand') == 'map' || query.get_equipped_item_name('off_hand') == 'shield'"
+              },
+              {
+                "two_hand": "query.get_equipped_item_name('off_hand') != 'map' && query.get_equipped_item_name('off_hand') != 'shield'"
+              }
+            ]
+          },
+          "one_hand": {
+            "animations": [
+              {
+                "first_person_map_hold_main_hand": "query.get_equipped_item_name(0, 1) == 'map'"
+              },
+              {
+                "first_person_map_hold_off_hand": "query.get_equipped_item_name('off_hand') == 'map' && (query.get_equipped_item_name == 'bow' ? !(variable.item_use_normalized > 0 && variable.item_use_normalized < 1.0) : 1.0)"
+              }
+            ],
+            "transitions": [
+              {
+                "default": "query.get_equipped_item_name(0, 1) != 'map' && query.get_equipped_item_name('off_hand') != 'map'"
+              },
+              {
+                "two_hand": "query.get_equipped_item_name('off_hand') != 'map' && query.get_equipped_item_name('off_hand') != 'shield'"
+              }
+            ]
+          },
+          "two_hand": {
+            "animations": [
+              "first_person_map_hold",
+              "first_person_map_hold_attack"
+            ],
+            "transitions": [
+              {
+                "default": "query.get_equipped_item_name(0, 1) != 'map' && query.get_equipped_item_name('off_hand') != 'map'"
+              },
+              {
+                "one_hand": "query.get_equipped_item_name('off_hand') == 'map' || query.get_equipped_item_name('off_hand') == 'shield'"
+              }
+            ]
+          }
+        }
+      },
+      "crossbow_controller": {
+        "initial_state": "default",
+        "states": {
+          "charge": {
+            "animations": ["third_person_crossbow_equipped"],
+            "transitions": [
+              {
+                "default": "query.get_equipped_item_name != 'crossbow' || (query.item_remaining_use_duration <= 0.0 && !query.item_is_charged)"
+              },
+              {"hold": "query.item_is_charged"}
+            ]
+          },
+          "default": {
+            "transitions": [
+              {"hold": "query.item_is_charged"},
+              {"charge": "query.item_remaining_use_duration > 0.0"}
+            ]
+          },
+          "hold": {
+            "animations": ["crossbow_hold"],
+            "transitions": [
+              {
+                "default": "query.get_equipped_item_name != 'crossbow' || (query.item_remaining_use_duration <= 0.0 && !query.item_is_charged)"
+              },
+              {"charge": "query.item_remaining_use_duration > 0.0"}
+            ]
+          }
+        }
+      },
+      "blink": {
+        "initial_state": "default",
+        "states": {
+          "default": {
+            "transitions": [
+              {
+                "open": "variable.is_blinking = 0; variable.last_blink_time = query.life_time; return variable.last_blink_time != 0;"
+              }
+            ]
+          },
+          "open": {
+            "transitions": [
+              {
+                "blink": "variable.is_blinking = 0; variable.return_from_blink = query.life_time + math.random(0, 0.2); return query.life_time > (variable.last_blink_time + math.random(3, 40));"
+              }
+            ]
+          },
+          "blink": {
+            "transitions": [
+              {
+                "open": "variable.is_blinking = 1; variable.last_blink_time = query.life_time; return query.all_animations_finished && (query.life_time > variable.return_from_blink);"
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
   "polar_bear": {
     "identifier": "minecraft:polar_bear",
     "materials": {"default": "polar_bear"},

--- a/viewer/lib/utils.electron.js
+++ b/viewer/lib/utils.electron.js
@@ -4,7 +4,7 @@ const path = require('path')
 const textureCache = {}
 function loadTexture (texture, cb) {
   if (textureCache[texture]) return cb(textureCache[texture])
-  const url = path.resolve(__dirname, '../../public/' + texture)
+  const url = /^https?:\/\//.test(texture) ? texture : path.resolve(__dirname, '../../public/' + texture)
   new THREE.TextureLoader().load(url, loaded => {
     textureCache[texture] = loaded
     cb(loaded)

--- a/viewer/lib/utils.electron.js
+++ b/viewer/lib/utils.electron.js
@@ -3,11 +3,12 @@ const path = require('path')
 
 const textureCache = {}
 function loadTexture (texture, cb) {
-  if (!textureCache[texture]) {
-    const url = path.resolve(__dirname, '../../public/' + texture)
-    textureCache[texture] = new THREE.TextureLoader().load(url)
-  }
-  cb(textureCache[texture])
+  if (textureCache[texture]) return cb(textureCache[texture])
+  const url = path.resolve(__dirname, '../../public/' + texture)
+  new THREE.TextureLoader().load(url, loaded => {
+    textureCache[texture] = loaded
+    cb(loaded)
+  }, undefined, () => {})
 }
 
 function loadJSON (json, cb) {

--- a/viewer/lib/utils.js
+++ b/viewer/lib/utils.js
@@ -19,7 +19,9 @@ function loadTexture (texture, cb) {
   if (textureCache[texture]) {
     cb(textureCache[texture])
   } else {
-    loadImage(path.resolve(__dirname, '../../public/' + texture)).then(image => {
+    // bundled textures are files under public/; player skins are http(s) URLs
+    const src = /^https?:\/\//.test(texture) ? texture : path.resolve(__dirname, '../../public/' + texture)
+    loadImage(src).then(image => {
       textureCache[texture] = new THREE.CanvasTexture(image)
       cb(textureCache[texture])
     }).catch(() => {})

--- a/viewer/lib/utils.js
+++ b/viewer/lib/utils.js
@@ -22,7 +22,7 @@ function loadTexture (texture, cb) {
     loadImage(path.resolve(__dirname, '../../public/' + texture)).then(image => {
       textureCache[texture] = new THREE.CanvasTexture(image)
       cb(textureCache[texture])
-    })
+    }).catch(() => {})
   }
 }
 

--- a/viewer/lib/utils.web.js
+++ b/viewer/lib/utils.web.js
@@ -4,7 +4,10 @@ const THREE = require('three')
 const textureCache = {}
 function loadTexture (texture, cb) {
   if (!textureCache[texture]) {
-    textureCache[texture] = new Promise(resolve => new THREE.TextureLoader().load(texture, resolve, undefined, () => {}))
+    // textures.minecraft.net sends no CORS headers: player skins go through the
+    // server's proxy route (lib/mineflayer.js)
+    const url = texture.replace(/^https?:\/\/textures\.minecraft\.net\/texture\//, 'texture/')
+    textureCache[texture] = new Promise(resolve => new THREE.TextureLoader().load(url, resolve, undefined, () => {}))
   }
   textureCache[texture].then(cb)
 }

--- a/viewer/lib/utils.web.js
+++ b/viewer/lib/utils.web.js
@@ -4,7 +4,7 @@ const THREE = require('three')
 const textureCache = {}
 function loadTexture (texture, cb) {
   if (!textureCache[texture]) {
-    textureCache[texture] = new Promise(resolve => new THREE.TextureLoader().load(texture, resolve))
+    textureCache[texture] = new Promise(resolve => new THREE.TextureLoader().load(texture, resolve, undefined, () => {}))
   }
   textureCache[texture].then(cb)
 }

--- a/viewer/lib/worldView.js
+++ b/viewer/lib/worldView.js
@@ -6,8 +6,18 @@ const EventEmitter = require('events')
 // online-mode servers); nothing for other entities or players without skin data
 function playerSkin (bot, e) {
   const skinData = e.username !== undefined && bot.players[e.username]?.skinData
-  if (!skinData) return {}
+  if (!skinData) return { skinModel: defaultSkinModel(e.uuid) }
   return { skin: skinData.url, skinModel: skinData.model, cape: skinData.capeUrl }
+}
+
+// Vanilla's DefaultPlayerSkin: a player without skin data is Alex when the Java hashCode of
+// their UUID is odd, which is the xor of the lowest bit of each 32-bit quarter.
+function defaultSkinModel (uuid) {
+  if (typeof uuid !== 'string') return undefined
+  const hex = uuid.replace(/-/g, '')
+  if (hex.length !== 32) return undefined
+  const odd = [7, 15, 23, 31].reduce((acc, i) => acc ^ parseInt(hex[i], 16), 0) & 1
+  return odd ? 'slim' : undefined
 }
 
 class WorldView extends EventEmitter {

--- a/viewer/lib/worldView.js
+++ b/viewer/lib/worldView.js
@@ -27,7 +27,7 @@ class WorldView extends EventEmitter {
       // 'move': botPosition,
       entitySpawn: function (e) {
         if (e === bot.entity) return
-        worldView.emitter.emit('entity', { id: e.id, name: e.name, pos: e.position, width: e.width, height: e.height, username: e.username, riding: !!e.vehicle })
+        worldView.emitter.emit('entity', { id: e.id, name: e.name, pos: e.position, width: e.width, height: e.height, username: e.username, riding: !!e.vehicle, skinModel: bot.players[e.username]?.skinData?.model })
       },
       entityMoved: function (e) {
         worldView.emitter.emit('entity', { id: e.id, pos: e.position, pitch: e.pitch, yaw: e.yaw })
@@ -60,7 +60,7 @@ class WorldView extends EventEmitter {
     for (const id in bot.entities) {
       const e = bot.entities[id]
       if (e && e !== bot.entity) {
-        this.emitter.emit('entity', { id: e.id, name: e.name, pos: e.position, width: e.width, height: e.height, username: e.username, riding: !!e.vehicle })
+        this.emitter.emit('entity', { id: e.id, name: e.name, pos: e.position, width: e.width, height: e.height, username: e.username, riding: !!e.vehicle, skinModel: bot.players[e.username]?.skinData?.model })
       }
     }
   }

--- a/viewer/lib/worldView.js
+++ b/viewer/lib/worldView.js
@@ -2,6 +2,14 @@ const { spiral, ViewRect, chunkPos } = require('./simpleUtils')
 const { Vec3 } = require('vec3')
 const EventEmitter = require('events')
 
+// Skin and cape texture URLs of a player entity (textures.minecraft.net on
+// online-mode servers); nothing for other entities or players without skin data
+function playerSkin (bot, e) {
+  const skinData = e.username !== undefined && bot.players[e.username]?.skinData
+  if (!skinData) return {}
+  return { skin: skinData.url, skinModel: skinData.model, cape: skinData.capeUrl }
+}
+
 class WorldView extends EventEmitter {
   constructor (world, viewDistance, position = new Vec3(0, 0, 0), emitter = null) {
     super()
@@ -27,7 +35,7 @@ class WorldView extends EventEmitter {
       // 'move': botPosition,
       entitySpawn: function (e) {
         if (e === bot.entity) return
-        worldView.emitter.emit('entity', { id: e.id, name: e.name, pos: e.position, width: e.width, height: e.height, username: e.username, riding: !!e.vehicle, skinModel: bot.players[e.username]?.skinData?.model, cape: bot.players[e.username]?.skinData?.capeUrl !== undefined })
+        worldView.emitter.emit('entity', { id: e.id, name: e.name, pos: e.position, width: e.width, height: e.height, username: e.username, riding: !!e.vehicle, ...playerSkin(bot, e) })
       },
       entityMoved: function (e) {
         worldView.emitter.emit('entity', { id: e.id, pos: e.position, pitch: e.pitch, yaw: e.yaw })
@@ -60,7 +68,7 @@ class WorldView extends EventEmitter {
     for (const id in bot.entities) {
       const e = bot.entities[id]
       if (e && e !== bot.entity) {
-        this.emitter.emit('entity', { id: e.id, name: e.name, pos: e.position, width: e.width, height: e.height, username: e.username, riding: !!e.vehicle, skinModel: bot.players[e.username]?.skinData?.model, cape: bot.players[e.username]?.skinData?.capeUrl !== undefined })
+        this.emitter.emit('entity', { id: e.id, name: e.name, pos: e.position, width: e.width, height: e.height, username: e.username, riding: !!e.vehicle, ...playerSkin(bot, e) })
       }
     }
   }

--- a/viewer/lib/worldView.js
+++ b/viewer/lib/worldView.js
@@ -27,7 +27,7 @@ class WorldView extends EventEmitter {
       // 'move': botPosition,
       entitySpawn: function (e) {
         if (e === bot.entity) return
-        worldView.emitter.emit('entity', { id: e.id, name: e.name, pos: e.position, width: e.width, height: e.height, username: e.username, riding: !!e.vehicle, skinModel: bot.players[e.username]?.skinData?.model })
+        worldView.emitter.emit('entity', { id: e.id, name: e.name, pos: e.position, width: e.width, height: e.height, username: e.username, riding: !!e.vehicle, skinModel: bot.players[e.username]?.skinData?.model, cape: bot.players[e.username]?.skinData?.capeUrl !== undefined })
       },
       entityMoved: function (e) {
         worldView.emitter.emit('entity', { id: e.id, pos: e.position, pitch: e.pitch, yaw: e.yaw })
@@ -60,7 +60,7 @@ class WorldView extends EventEmitter {
     for (const id in bot.entities) {
       const e = bot.entities[id]
       if (e && e !== bot.entity) {
-        this.emitter.emit('entity', { id: e.id, name: e.name, pos: e.position, width: e.width, height: e.height, username: e.username, riding: !!e.vehicle, skinModel: bot.players[e.username]?.skinData?.model })
+        this.emitter.emit('entity', { id: e.id, name: e.name, pos: e.position, width: e.width, height: e.height, username: e.username, riding: !!e.vehicle, skinModel: bot.players[e.username]?.skinData?.model, cape: bot.players[e.username]?.skinData?.capeUrl !== undefined })
       }
     }
   }


### PR DESCRIPTION
Closes #57. Continues where #247 / #334 / #360 left off, with less surface area.

## How it works
- `viewer/lib/worldView.js` sends each player entity's skin and cape texture URLs (`skin`, `cape`) and skin model (`skinModel`) from `bot.players[username].skinData` (mineflayer already parses the textures property). `viewer/lib/entities.js` hands them to `Entity` as a per-geometry texture map. A geometry with a default texture (the body) loads the override on top once the default has loaded, so ordering can't leave a player textureless. A geometry without one (the cape) is only rendered when an override is supplied.
- Entity textures load on the mesh's first render (`onBeforeRender`), not on spawn, so a player the camera never sees costs no fetch.
- The node `loadTexture` fetches http(s) URLs directly (node-canvas `loadImage` takes URLs), so the headless viewer renders skins with no web server involved. The browser can't fetch `textures.minecraft.net` (no CORS headers), so `utils.web` rewrites those URLs to `texture/<hash>`, which `lib/mineflayer.js` proxies. Only that host, by texture hash, so it can't be used as an open proxy.
- Both skin formats are supported. Slim players use a new `player_slim` model in `entities.json` (3-wide arms, Alex default texture). Skins predating 1.8 (64x32) are upgraded to the 64x64 layout the same way vanilla does (mirrored limbs, unused hat dropped), as pixel operations so the headless viewer needs no node-canvas for it.
- Capes use the existing `cape` geometry of the player model. The cape URL comes from `skinData.capeUrl`, which needs PrismarineJS/mineflayer#4046. Without it every player just has no cape.
- Entity models are mirrored on x like vanilla draws them (the geometry json is Bedrock model space, left arm at +x). Before, a player's left limbs and their left-limb textures sat on the right, and the top face of every cube was mirrored; the face UV table is laid out for the mirror so every cube face now matches vanilla's `ModelPart.Cube`.
- Base layers are forced opaque like vanilla's `HttpTexture` (head, body row, lower limbs), so only the second layer is see-through. Slim arms sit half a pixel lower and the cape hangs at 6 degrees, as in vanilla. Players without skin data get Steve or Alex by UUID parity (`DefaultPlayerSkin`).
- `loadTexture` (web, electron, node) now ignores load failures. Players without skin data (offline-mode servers) keep Steve/Alex, instead of a broken material or an unhandled rejection crashing node.

No new dependencies.

## Tested
Ran a 1.21.4 offline server with bots, set `skinData` on them from `bot.players` (wide, `model: 'slim'`, and one with `capeUrl` set to the Migrator cape), and opened the viewer in puppeteer: both skin formats render with the skin, the slim one with narrow arms, and the caped player has the cape on its back, while the bot's own mesh stays Steve. `/texture/<hash>` returns `200 image/png`, an unknown hash 404, no page errors. In node, `loadTexture` on a skin URL yields a 64x64 texture and a bad URL never calls back. A synthetic skin with a marked corner on every head face and coloured arms, rendered headless from six directions, lands each face, mark and limb where vanilla's cube code puts them; Notch's 64x32 skin renders identically through node-canvas and pngjs.

Note: the client bundle needs #489 to render at all on current webpack; unrelated to this change.
