### PR TITLE
Animate limbs of walking entities

### DIFF
--- a/viewer/lib/entities.js
+++ b/viewer/lib/entities.js
@@ -31,8 +31,11 @@ function getEntityMesh (entity, scene) {
 
         e.mesh.add(sprite)
       }
-      const limbs = ['leftArm', 'rightArm', 'leftLeg', 'rightLeg'].map(name => e.mesh.getObjectByName(name))
-      if (limbs.every(Boolean)) e.mesh.walk = { limbs, lastPos: null, speed: 0, pos: 0 }
+      const limbs = {}
+      for (const name of ['leftArm', 'rightArm', 'leftLeg', 'rightLeg']) limbs[name] = e.mesh.getObjectByName(name)
+      if (Object.values(limbs).every(Boolean)) {
+        e.mesh.walk = { limbs, lastPos: null, speed: 0, pos: 0, age: 0, riding: false, zombieArms: zombieArmMobs.has(entity.name) }
+      }
 
       return e.mesh
     } catch (err) {
@@ -47,23 +50,49 @@ function getEntityMesh (entity, scene) {
   return cube
 }
 
+// mobs whose model applies AnimationUtils.animateZombieArms instead of the humanoid arm swing
+const zombieArmMobs = new Set(['zombie', 'husk', 'drowned', 'zombie_villager', 'zombified_piglin'])
+
+// Vanilla rotations are in a y-down model space; this model is y-up, so x and z angles are negated
 function animateWalk (mesh, ticks) {
-  const { limbs, lastPos } = mesh.walk
-  mesh.walk.lastPos = mesh.position.clone()
+  const w = mesh.walk
+  const lastPos = w.lastPos
+  w.lastPos = mesh.position.clone()
+  w.age += ticks
   if (!lastPos) return
-  const moved = Math.hypot(mesh.position.x - lastPos.x, mesh.position.z - lastPos.z)
 
-  const target = Math.min(1, moved / ticks * 4)
-  mesh.walk.speed += (target - mesh.walk.speed) * (1 - Math.pow(0.6, ticks))
-  mesh.walk.pos += mesh.walk.speed * ticks
+  // LivingEntity.calculateEntityAnimation / WalkAnimationState
+  if (w.riding) {
+    w.speed = 0
+    w.pos = 0
+  } else {
+    const moved = Math.hypot(mesh.position.x - lastPos.x, mesh.position.z - lastPos.z)
+    const target = Math.min(1, moved / ticks * 4)
+    w.speed += (target - w.speed) * (1 - Math.pow(0.6, ticks))
+    w.pos += w.speed * ticks
+  }
 
-  const [leftArm, rightArm, leftLeg, rightLeg] = limbs
-  const { speed, pos } = mesh.walk
+  // HumanoidModel.setupAnim
+  const { leftArm, rightArm, leftLeg, rightLeg } = w.limbs
+  const { speed, pos } = w
   const t = pos * 0.6662
-  leftArm.rotation.x = Math.cos(t) * speed
-  rightArm.rotation.x = Math.cos(t + Math.PI) * speed
-  leftLeg.rotation.x = Math.cos(t + Math.PI) * 1.4 * speed
-  rightLeg.rotation.x = Math.cos(t) * 1.4 * speed
+  leftArm.rotation.set(-Math.cos(t) * speed, 0, 0)
+  rightArm.rotation.set(-Math.cos(t + Math.PI) * speed, 0, 0)
+  leftLeg.rotation.set(-Math.cos(t + Math.PI) * 1.4 * speed, -0.005, 0.005)
+  rightLeg.rotation.set(-Math.cos(t) * 1.4 * speed, 0.005, -0.005)
+  if (w.riding) {
+    leftArm.rotation.x += Math.PI / 5
+    rightArm.rotation.x += Math.PI / 5
+    leftLeg.rotation.set(1.4137167, -Math.PI / 10, 0.07853982)
+    rightLeg.rotation.set(1.4137167, Math.PI / 10, -0.07853982)
+  }
+
+  // AnimationUtils.animateZombieArms (no attack) + bobArms
+  if (w.zombieArms) {
+    const age = w.age
+    leftArm.rotation.set(Math.PI / 2.25 + Math.sin(age * 0.067) * 0.05, 0.1, Math.cos(age * 0.09) * 0.05 + 0.05)
+    rightArm.rotation.set(Math.PI / 2.25 - Math.sin(age * 0.067) * 0.05, -0.1, -(Math.cos(age * 0.09) * 0.05 + 0.05))
+  }
 }
 
 class Entities {
@@ -93,6 +122,7 @@ class Entities {
 
   update (entity) {
     if (!this.entities[entity.id]) {
+      if (!entity.pos) return
       const mesh = getEntityMesh(entity, this.scene)
       if (!mesh) return
       this.entities[entity.id] = mesh
@@ -110,6 +140,10 @@ class Entities {
 
     if (entity.pos) {
       new TWEEN.Tween(e.position).to({ x: entity.pos.x, y: entity.pos.y, z: entity.pos.z }, 50).start()
+    }
+    if (e.walk) {
+      if (entity.riding !== undefined) e.walk.riding = entity.riding
+      if (entity.hurt) e.walk.speed = 1.5
     }
     if (entity.yaw) {
       const da = (entity.yaw - e.rotation.y) % (Math.PI * 2)

--- a/viewer/lib/entities.js
+++ b/viewer/lib/entities.js
@@ -31,6 +31,9 @@ function getEntityMesh (entity, scene) {
 
         e.mesh.add(sprite)
       }
+      const limbs = ['leftArm', 'rightArm', 'leftLeg', 'rightLeg'].map(name => e.mesh.getObjectByName(name))
+      if (limbs.every(Boolean)) e.mesh.walk = { limbs, lastPos: null, speed: 0, pos: 0 }
+
       return e.mesh
     } catch (err) {
       console.log(err)
@@ -44,10 +47,40 @@ function getEntityMesh (entity, scene) {
   return cube
 }
 
+function animateWalk (mesh, ticks) {
+  const { limbs, lastPos } = mesh.walk
+  mesh.walk.lastPos = mesh.position.clone()
+  if (!lastPos) return
+  const moved = Math.hypot(mesh.position.x - lastPos.x, mesh.position.z - lastPos.z)
+
+  const target = Math.min(1, moved / ticks * 4)
+  mesh.walk.speed += (target - mesh.walk.speed) * (1 - Math.pow(0.6, ticks))
+  mesh.walk.pos += mesh.walk.speed * ticks
+
+  const [leftArm, rightArm, leftLeg, rightLeg] = limbs
+  const { speed, pos } = mesh.walk
+  const t = pos * 0.6662
+  leftArm.rotation.x = Math.cos(t) * speed
+  rightArm.rotation.x = Math.cos(t + Math.PI) * speed
+  leftLeg.rotation.x = Math.cos(t + Math.PI) * 1.4 * speed
+  rightLeg.rotation.x = Math.cos(t) * 1.4 * speed
+}
+
 class Entities {
   constructor (scene) {
     this.scene = scene
     this.entities = {}
+    this.lastAnimate = performance.now()
+  }
+
+  animate () {
+    const now = performance.now()
+    const ticks = (now - this.lastAnimate) / 50
+    this.lastAnimate = now
+    if (ticks === 0) return
+    for (const mesh of Object.values(this.entities)) {
+      if (mesh.walk) animateWalk(mesh, ticks)
+    }
   }
 
   clear () {
@@ -64,6 +97,7 @@ class Entities {
       if (!mesh) return
       this.entities[entity.id] = mesh
       this.scene.add(mesh)
+      if (entity.pos) mesh.position.set(entity.pos.x, entity.pos.y, entity.pos.z)
     }
 
     const e = this.entities[entity.id]

--- a/viewer/lib/entities.js
+++ b/viewer/lib/entities.js
@@ -50,7 +50,6 @@ function getEntityMesh (entity, scene) {
   return cube
 }
 
-// mobs whose model applies AnimationUtils.animateZombieArms instead of the humanoid arm swing
 const zombieArmMobs = new Set(['zombie', 'husk', 'drowned', 'zombie_villager', 'zombified_piglin'])
 
 // Vanilla rotations are in a y-down model space; this model is y-up, so x and z angles are negated
@@ -61,7 +60,6 @@ function animateWalk (mesh, ticks) {
   w.age += ticks
   if (!lastPos) return
 
-  // LivingEntity.calculateEntityAnimation / WalkAnimationState
   if (w.riding) {
     w.speed = 0
     w.pos = 0
@@ -72,7 +70,6 @@ function animateWalk (mesh, ticks) {
     w.pos += w.speed * ticks
   }
 
-  // HumanoidModel.setupAnim
   const { leftArm, rightArm, leftLeg, rightLeg } = w.limbs
   const { speed, pos } = w
   const t = pos * 0.6662
@@ -87,7 +84,6 @@ function animateWalk (mesh, ticks) {
     rightLeg.rotation.set(1.4137167, Math.PI / 10, -0.07853982)
   }
 
-  // AnimationUtils.animateZombieArms (no attack) + bobArms
   if (w.zombieArms) {
     const age = w.age
     leftArm.rotation.set(Math.PI / 2.25 + Math.sin(age * 0.067) * 0.05, 0.1, Math.cos(age * 0.09) * 0.05 + 0.05)

--- a/viewer/lib/entity/Entity.js
+++ b/viewer/lib/entity/Entity.js
@@ -142,6 +142,7 @@ function getMesh (texture, jsonModel) {
   let i = 0
   for (const jsonBone of jsonModel.bones) {
     const bone = new THREE.Bone()
+    bone.name = jsonBone.name
     if (jsonBone.pivot) {
       bone.position.x = jsonBone.pivot[0]
       bone.position.y = jsonBone.pivot[1]
@@ -168,8 +169,13 @@ function getMesh (texture, jsonModel) {
 
   const rootBones = []
   for (const jsonBone of jsonModel.bones) {
-    if (jsonBone.parent) bones[jsonBone.parent].add(bones[jsonBone.name])
-    else rootBones.push(bones[jsonBone.name])
+    if (jsonBone.parent) {
+      const parentPivot = jsonModel.bones.find(b => b.name === jsonBone.parent).pivot
+      const bone = bones[jsonBone.name]
+      // pivots are absolute in the json, bone positions are relative to the parent
+      if (parentPivot) bone.position.sub(new THREE.Vector3(...parentPivot))
+      bones[jsonBone.parent].add(bone)
+    } else rootBones.push(bones[jsonBone.name])
   }
 
   const skeleton = new THREE.Skeleton(Object.values(bones))

--- a/viewer/lib/viewer.js
+++ b/viewer/lib/viewer.js
@@ -117,6 +117,7 @@ class Viewer {
   update () {
     TWEEN.update()
     this.world.update()
+    this.entities.animate()
   }
 
   async waitForChunksToRender () {

--- a/viewer/lib/worldView.js
+++ b/viewer/lib/worldView.js
@@ -27,10 +27,19 @@ class WorldView extends EventEmitter {
       // 'move': botPosition,
       entitySpawn: function (e) {
         if (e === bot.entity) return
-        worldView.emitter.emit('entity', { id: e.id, name: e.name, pos: e.position, width: e.width, height: e.height, username: e.username })
+        worldView.emitter.emit('entity', { id: e.id, name: e.name, pos: e.position, width: e.width, height: e.height, username: e.username, riding: !!e.vehicle })
       },
       entityMoved: function (e) {
         worldView.emitter.emit('entity', { id: e.id, pos: e.position, pitch: e.pitch, yaw: e.yaw })
+      },
+      entityAttach: function (e) {
+        worldView.emitter.emit('entity', { id: e.id, riding: true })
+      },
+      entityDetach: function (e) {
+        worldView.emitter.emit('entity', { id: e.id, riding: false })
+      },
+      entityHurt: function (e) {
+        worldView.emitter.emit('entity', { id: e.id, hurt: true })
       },
       entityGone: function (e) {
         worldView.emitter.emit('entity', { id: e.id, delete: true })
@@ -51,7 +60,7 @@ class WorldView extends EventEmitter {
     for (const id in bot.entities) {
       const e = bot.entities[id]
       if (e && e !== bot.entity) {
-        this.emitter.emit('entity', { id: e.id, name: e.name, pos: e.position, width: e.width, height: e.height, username: e.username })
+        this.emitter.emit('entity', { id: e.id, name: e.name, pos: e.position, width: e.width, height: e.height, username: e.username, riding: !!e.vehicle })
       }
     }
   }


### PR DESCRIPTION
Entities with `leftArm`/`rightArm`/`leftLeg`/`rightLeg` bones (players, zombies, skeletons, ...) now swing their limbs while moving, and settle back to rest when they stop.

The swing follows vanilla: `LivingEntity.updateWalkAnimation` for the speed/position accumulators (target `min(1, dist * 4)` per tick, lerped by 0.4) and `HumanoidModel.setupAnim` for the limb angles (`cos(pos * 0.6662) * 1.4 * speed` for legs, half that for arms, opposite phases). It is driven per frame from `Viewer.update()` by how far the (tweened) mesh moved since the last frame, so nothing new has to be sent over the socket for walking itself.

Other vanilla poses covered (second commit):
- Zombies, husks, drowned, zombie villagers and zombified piglins hold their arms out with the idle bob (`AnimationUtils.animateZombieArms` + `bobArms`); only their legs follow the walk cycle.
- Passengers get the vanilla sitting pose and their walk state is reset. `WorldView` forwards mineflayer's `entityAttach`/`entityDetach` as a `riding` flag for this.
- A hurt entity kicks its walk speed to 1.5 like `LivingEntity.hurt`, forwarded from `entityHurt`.
- Rotation signs follow vanilla's: the bedrock-style model is y-up while the java model is y-down, so vanilla x and z angles are negated.

To make bone rotation work at all, `Entity.js` now positions bones relative to their parent pivot. Previously bones were parented while keeping their absolute pivot, so the bind pose had each child bone offset by all its ancestors' pivots and rotating a bone swung its cubes around the wrong point. Bones also get their json name so limbs can be looked up with `getObjectByName`.

Also: new entities are placed at their spawn position instead of tweening in from the origin, which would otherwise register as a large first-frame move. `Entities.update` now ignores messages for ids it has never seen that carry no position, instead of creating an empty mesh for them.

Not covered here: the bot's own mesh in `lib/index.js` (`botMesh`) is not managed by `Entities`, so it does not animate yet. Elytra `speedValue` scaling and baby `positionScale` need state the viewer does not receive.

Tested with headless renders of a player, skeleton, drowned and a riding player (video in the comments): limbs rotate about hip/shoulder, head and body stay put, zombie-family arms stay out, and limb rotation decays to ~1e-7 within a second of the entity stopping.