### PR TITLE
Keep the server's version for block data, snap only the assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Web based viewer for servers and bots
 
 [<img src="https://prismarinejs.github.io/prismarine-viewer/test_1.18.1.png" alt="viewer" width="300">](https://prismarinejs.github.io/prismarine-viewer/)
 
-Supports versions 1.8.8, 1.9.4, 1.10.2, 1.11.2, 1.12.2, 1.13.2, 1.14.4, 1.15.2, 1.16.1, 1.16.4, 1.17.1, 1.18.1, 1.19, 1.20.1, 1.21.1, 1.21.4.
+Supports versions 1.8.8, 1.9.4, 1.10.2, 1.11.2, 1.12.2, 1.13.2, 1.14.4, 1.15.2, 1.16.1, 1.16.4, 1.17.1, 1.18.1, 1.19, 1.20.1, 1.21.1, 1.21.4. Other versions of the same major (e.g. 1.21.8) render with the textures and models of the closest supported one.
 
 ## Install
 

--- a/viewer/lib/viewer.js
+++ b/viewer/lib/viewer.js
@@ -38,16 +38,16 @@ class Viewer {
   }
 
   setVersion (version) {
-    version = getVersion(version)
-    if (version === null) {
+    const assetsVersion = getVersion(version)
+    if (assetsVersion === null) {
       const msg = `${version} is not supported`
       window.alert(msg)
       console.log(msg)
       return false
     }
-    console.log('Using version: ' + version)
+    console.log(`Using version: ${version} (assets: ${assetsVersion})`)
     this.version = version
-    this.world.setVersion(version)
+    this.world.setVersion(version, assetsVersion)
     this.entities.clear()
     this.primitives.clear()
     return true

--- a/viewer/lib/worldrenderer.js
+++ b/viewer/lib/worldrenderer.js
@@ -14,6 +14,7 @@ class WorldRenderer {
     this.sectionMeshs = {}
     this.active = false
     this.version = undefined
+    this.assetsVersion = undefined
     this.scene = scene
     this.loadedChunks = {}
     this.sectionsOutstanding = new Set()
@@ -75,8 +76,9 @@ class WorldRenderer {
     }
   }
 
-  setVersion (version) {
+  setVersion (version, assetsVersion = version) {
     this.version = version
+    this.assetsVersion = assetsVersion
     this.resetWorld()
     this.active = true
     for (const worker of this.workers) {
@@ -87,7 +89,7 @@ class WorldRenderer {
   }
 
   updateTexturesData () {
-    loadTexture(this.texturesDataUrl || `textures/${this.version}.png`, texture => {
+    loadTexture(this.texturesDataUrl || `textures/${this.assetsVersion}.png`, texture => {
       texture.magFilter = THREE.NearestFilter
       texture.minFilter = THREE.NearestFilter
       texture.flipY = false
@@ -97,7 +99,7 @@ class WorldRenderer {
     const loadBlockStates = () => {
       return new Promise(resolve => {
         if (this.blockStatesData) return resolve(this.blockStatesData)
-        return loadJSON(`blocksStates/${this.version}.json`, resolve)
+        return loadJSON(`blocksStates/${this.assetsVersion}.json`, resolve)
       })
     }
     loadBlockStates().then((blockStates) => {


### PR DESCRIPTION
`Viewer.setVersion` snapped the whole viewer to the newest bundled asset version of the same major, so a 1.21.8 world was decoded with 1.21.4 block state ids. Ids drift from 2051 onward (1.21.5 added `bush`), so every block above that rendered as the wrong block: obsidian showed as wall torches and nether portals as cakes.

The mesher already looks blocks up by name, so the worker's `World` can use the server's own version (minecraft-data / prismarine-chunk support it) while textures and block states keep coming from the closest supported asset version.

Verified with a headless render of a 1.21.8 chunk holding an obsidian frame + `nether_portal`: before, torches and cakes; after, the portal renders. Blocks that only exist in the newer version still fall back to the missing texture as before.
