### PR TITLE
Animate textures that ship a .mcmeta animation strip

### DIFF
--- a/viewer/lib/atlas.js
+++ b/viewer/lib/atlas.js
@@ -21,34 +21,71 @@ function readTexture (basePath, name) {
   return fs.readFileSync(path.join(basePath, name), 'base64')
 }
 
+// An animated texture is a vertical strip of square frames described by a
+// .mcmeta next to it. Frame order and per-frame durations are baked into the
+// atlas as repeated tiles, so the shader only needs a frame count and one
+// frame time (in ticks). "interpolate" is ignored.
+function readAnimation (basePath, name, img) {
+  const mcmetaPath = path.join(basePath, name + '.mcmeta')
+  if (img.height <= img.width || !fs.existsSync(mcmetaPath)) return null
+  const { animation } = JSON.parse(fs.readFileSync(mcmetaPath, 'utf8'))
+  if (!animation) return null
+  const frametime = animation.frametime || 1
+  const frameCount = Math.floor(img.height / img.width)
+  const frames = animation.frames || [...Array(frameCount).keys()]
+  return {
+    frametime,
+    frameHeight: img.width,
+    frames: frames.flatMap(f => typeof f === 'number' ? [f] : Array(Math.max(1, Math.round(f.time / frametime))).fill(f.index))
+  }
+}
+
 function makeTextureAtlas (mcAssets) {
   const blocksTexturePath = path.join(mcAssets.directory, '/blocks')
   const textureFiles = fs.readdirSync(blocksTexturePath).filter(file => file.endsWith('.png'))
   textureFiles.unshift('missing_texture.png')
 
-  const texSize = nextPowerOfTwo(Math.ceil(Math.sqrt(textureFiles.length)))
   const tileSize = 16
 
-  const imgSize = texSize * tileSize
-  const canvas = new Canvas(imgSize, imgSize, 'png')
+  const textures = textureFiles.map(file => {
+    const img = new Image()
+    img.src = 'data:image/png;base64,' + readTexture(blocksTexturePath, file)
+    const animation = readAnimation(blocksTexturePath, file, img)
+    return { name: file.split('.')[0], img, animation, frames: animation ? animation.frames : [0], frameHeight: animation ? animation.frameHeight : tileSize }
+  })
+
+  // Each texture takes a vertical run of tiles (one per frame). Tallest first,
+  // each into the currently shortest column, so strips never straddle columns.
+  const tileCount = textures.reduce((n, tex) => n + tex.frames.length, 0)
+  const texSize = nextPowerOfTwo(Math.ceil(Math.sqrt(tileCount)))
+  const columns = new Array(texSize).fill(0)
+  textures.sort((a, b) => b.frames.length - a.frames.length)
+  for (const tex of textures) {
+    const col = columns.indexOf(Math.min(...columns))
+    tex.x = col * tileSize
+    tex.y = columns[col] * tileSize
+    columns[col] += tex.frames.length
+  }
+
+  const imgWidth = texSize * tileSize
+  const imgHeight = nextPowerOfTwo(Math.max(...columns) * tileSize)
+  const canvas = new Canvas(imgWidth, imgHeight, 'png')
   const g = canvas.getContext('2d')
 
   const texturesIndex = {}
 
-  for (const i in textureFiles) {
-    const x = (i % texSize) * tileSize
-    const y = Math.floor(i / texSize) * tileSize
-
-    const name = textureFiles[i].split('.')[0]
-
-    texturesIndex[name] = { u: x / imgSize, v: y / imgSize, su: tileSize / imgSize, sv: tileSize / imgSize }
-
-    const img = new Image()
-    img.src = 'data:image/png;base64,' + readTexture(blocksTexturePath, textureFiles[i])
-    g.drawImage(img, 0, 0, 16, 16, x, y, 16, 16)
+  for (const tex of textures) {
+    texturesIndex[tex.name] = { u: tex.x / imgWidth, v: tex.y / imgHeight, su: tileSize / imgWidth, sv: tileSize / imgHeight }
+    if (tex.animation) {
+      texturesIndex[tex.name].frames = tex.frames.length
+      texturesIndex[tex.name].frametime = tex.animation.frametime
+    }
+    tex.frames.forEach((frame, i) => {
+      g.drawImage(tex.img, 0, frame * tex.frameHeight, tileSize, tileSize, tex.x, tex.y + i * tileSize, tileSize, tileSize)
+    })
   }
 
-  return { image: canvas.toBuffer(), canvas, json: { size: tileSize / imgSize, textures: texturesIndex } }
+  return { image: canvas.toBuffer(), canvas, json: { tileSize, width: imgWidth, height: imgHeight, textures: texturesIndex } }
 }
 
 module.exports = {

--- a/viewer/lib/models.js
+++ b/viewer/lib/models.js
@@ -154,6 +154,7 @@ function renderLiquid (world, cursor, texture, type, biome, water, attr) {
         (pos[2] ? 1 : 0) + (cursor.z & 15) - 8)
       attr.t_normals.push(...dir)
       attr.t_uvs.push(pos[3] * su + u, pos[4] * sv * (pos[1] ? 1 : height) + v)
+      attr.t_animations.push(texture.frames || 1, texture.frametime || 1)
       attr.t_colors.push(tint[0], tint[1], tint[2])
     }
   }
@@ -321,6 +322,7 @@ function renderElement (world, cursor, element, doAO, attr, globalMatrix, global
       const baseu = (pos[3] - 0.5) * uvcs - (pos[4] - 0.5) * uvsn + 0.5
       const basev = (pos[3] - 0.5) * uvsn + (pos[4] - 0.5) * uvcs + 0.5
       attr.uvs.push(baseu * su + u, basev * sv + v)
+      attr.animations.push(eFace.texture.frames || 1, eFace.texture.frametime || 1)
 
       let light = 1
       if (doAO) {
@@ -371,10 +373,12 @@ function getSectionGeometry (sx, sy, sz, world, blocksStates) {
     normals: [],
     colors: [],
     uvs: [],
+    animations: [],
     t_positions: [],
     t_normals: [],
     t_colors: [],
     t_uvs: [],
+    t_animations: [],
     indices: []
   }
 
@@ -436,16 +440,19 @@ function getSectionGeometry (sx, sy, sz, world, blocksStates) {
   attr.normals.push(...attr.t_normals)
   attr.colors.push(...attr.t_colors)
   attr.uvs.push(...attr.t_uvs)
+  attr.animations.push(...attr.t_animations)
 
   delete attr.t_positions
   delete attr.t_normals
   delete attr.t_colors
   delete attr.t_uvs
+  delete attr.t_animations
 
   attr.positions = new Float32Array(attr.positions)
   attr.normals = new Float32Array(attr.normals)
   attr.colors = new Float32Array(attr.colors)
   attr.uvs = new Float32Array(attr.uvs)
+  attr.animations = new Float32Array(attr.animations)
 
   return attr
 }

--- a/viewer/lib/utils.web.js
+++ b/viewer/lib/utils.web.js
@@ -4,9 +4,9 @@ const THREE = require('three')
 const textureCache = {}
 function loadTexture (texture, cb) {
   if (!textureCache[texture]) {
-    textureCache[texture] = new THREE.TextureLoader().load(texture)
+    textureCache[texture] = new Promise(resolve => new THREE.TextureLoader().load(texture, resolve))
   }
-  cb(textureCache[texture])
+  textureCache[texture].then(cb)
 }
 
 function loadJSON (url, callback) {

--- a/viewer/lib/viewer.js
+++ b/viewer/lib/viewer.js
@@ -116,6 +116,7 @@ class Viewer {
 
   update () {
     TWEEN.update()
+    this.world.update()
   }
 
   async waitForChunksToRender () {

--- a/viewer/lib/worker.js
+++ b/viewer/lib/worker.js
@@ -77,7 +77,7 @@ setInterval(() => {
     if (chunk && chunk.sections[Math.floor(y / 16)]) {
       delete dirtySections[key]
       const geometry = getSectionGeometry(x, y, z, world, blocksStates)
-      const transferable = [geometry.positions.buffer, geometry.normals.buffer, geometry.colors.buffer, geometry.uvs.buffer]
+      const transferable = [geometry.positions.buffer, geometry.normals.buffer, geometry.colors.buffer, geometry.uvs.buffer, geometry.animations.buffer]
       postMessage({ type: 'geometry', key, geometry }, transferable)
     }
     postMessage({ type: 'sectionFinished', key })

--- a/viewer/lib/worldrenderer.js
+++ b/viewer/lib/worldrenderer.js
@@ -22,6 +22,15 @@ class WorldRenderer {
     this.texturesDataUrl = undefined
 
     this.material = new THREE.MeshLambertMaterial({ vertexColors: true, transparent: true, alphaTest: 0.1 })
+    // Animated textures are packed as vertical runs of tiles; each vertex
+    // carries (frames, frametime) and the shader steps down the run in ticks.
+    this.uniforms = { time: { value: 0 }, tileHeight: { value: 0 } }
+    this.material.onBeforeCompile = (shader) => {
+      Object.assign(shader.uniforms, this.uniforms)
+      shader.vertexShader = shader.vertexShader
+        .replace('#include <common>', 'attribute vec2 animation;\nuniform float time;\nuniform float tileHeight;\n#include <common>')
+        .replace('#include <uv_vertex>', '#include <uv_vertex>\n#ifdef USE_UV\nvUv.y += mod(floor(time / animation.y), animation.x) * tileHeight;\n#endif')
+    }
 
     this.workers = []
     for (let i = 0; i < numWorkers; i++) {
@@ -48,6 +57,7 @@ class WorldRenderer {
           geometry.setAttribute('normal', new THREE.BufferAttribute(data.geometry.normals, 3))
           geometry.setAttribute('color', new THREE.BufferAttribute(data.geometry.colors, 3))
           geometry.setAttribute('uv', new THREE.BufferAttribute(data.geometry.uvs, 2))
+          geometry.setAttribute('animation', new THREE.BufferAttribute(data.geometry.animations, 2))
           geometry.setIndex(data.geometry.indices)
 
           mesh = new THREE.Mesh(geometry, this.material)
@@ -91,7 +101,9 @@ class WorldRenderer {
       texture.magFilter = THREE.NearestFilter
       texture.minFilter = THREE.NearestFilter
       texture.flipY = false
+      this.uniforms.tileHeight.value = 16 / texture.image.height
       this.material.map = texture
+      this.material.needsUpdate = true
     })
 
     const loadBlockStates = () => {
@@ -105,6 +117,10 @@ class WorldRenderer {
         worker.postMessage({ type: 'blockStates', json: blockStates })
       }
     })
+  }
+
+  update () {
+    this.uniforms.time.value = performance.now() / 50
   }
 
   addColumn (x, z, chunk) {


### PR DESCRIPTION
The atlas only ever copied the first 16x16 of each texture, so water, lava, fire, nether portals and every other `.mcmeta` animated texture sat frozen on frame 0.

- `atlas.js` packs every frame of an animated strip as a vertical run of tiles. Frame order and per-frame durations from the `.mcmeta` are baked into the run at prerender time, so each texture reduces to a frame count and a single frame time in ticks (`interpolate` is ignored). Textures are placed tallest-first into the shortest column, so a run never straddles columns. The atlas can now be non-square; `su`/`sv` are per axis.
- `models.js` emits a per-vertex `animation` attribute `(frames, frametime)` for both block faces and liquids.
- `worldrenderer.js` hooks `onBeforeCompile` on the shared material to step `vUv.y` by `mod(floor(time / frametime), frames) * tileHeight`, with `time` updated in ticks from `viewer.update()`.

Verified with a headless render of a nether portal at two different ticks: only the portal pixels change. The 1.21.4 atlas stays 1024x1024.
