### PR TITLE
Load assets and spawn workers through a host object

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,11 @@ Options:
 * `frames` number of frames to record, `-1` for infinite, default: `200`
 * `width` the width of a frame, default: `512`
 * `height` the height of a frame, default: `512`
+* `numWorkers` mesher worker threads, default: `4`
 
 [example](https://github.com/PrismarineJS/prismarine-viewer/blob/master/examples/headless.js)
+
+`headless` renders through `node-canvas-webgl`. To render with another GL context (headless-gl, a custom renderer) use the core API with the node host, which needs no native module: see [viewer/README.md](viewer/README.md#hosts) and [examples/core/headless.js](examples/core/headless.js).
 
 ### Drawing (mineflayer mode)
 

--- a/examples/core/headless.js
+++ b/examples/core/headless.js
@@ -1,21 +1,18 @@
-/* global THREE */
-
 /*
 This is an example of using only the core API (.viewer) to implement rendering a world and saving a video of it
 */
 
 const { spawn } = require('child_process')
 const net = require('net')
-global.THREE = require('three')
-global.Worker = require('worker_threads').Worker
+const THREE = require('three')
 const { createCanvas } = require('node-canvas-webgl/lib')
 
-const { Viewer, WorldView, getBufferFromStream } = require('..').viewer
+const { Viewer, WorldView, getBufferFromStream, createNodeHost } = require('..').viewer
 
 const start = (bot, { viewDistance = 6, output = 'output.mp4', frames = 200, width = 512, height = 512 } = {}) => {
   const canvas = createCanvas(width, height)
   const renderer = new THREE.WebGLRenderer({ canvas })
-  const viewer = new Viewer(renderer)
+  const viewer = new Viewer(renderer, { host: createNodeHost() })
 
   if (!viewer.setVersion(bot.version)) {
     return false

--- a/examples/electron/client/localViewer.js
+++ b/examples/electron/client/localViewer.js
@@ -1,5 +1,5 @@
 /* global THREE */
-const { WorldView, Viewer, MapControls } = require('prismarine-viewer/viewer')
+const { WorldView, Viewer, MapControls, createElectronHost } = require('prismarine-viewer/viewer')
 const { Vec3 } = require('vec3')
 global.THREE = require('three')
 
@@ -27,7 +27,7 @@ class LocalViewer {
     document.body.appendChild(this.renderer.domElement)
 
     // Create viewer
-    this.viewer = new Viewer(this.renderer)
+    this.viewer = new Viewer(this.renderer, { host: createElectronHost() })
     if (!this.viewer.setVersion(this.version)) {
       return false
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,15 +23,47 @@ export function headless(bot: Bot, settings: {
     width?: number;
     height?: number;
     logFFMPEG?: boolean;
-    jpegOption: any;
+    jpegOption?: any;
+    numWorkers?: number;
 });
+
+export interface HostImage {
+    width: number;
+    height: number;
+    /** RGBA bytes, top row first */
+    data: Uint8Array;
+}
+
+export interface HostWorker {
+    postMessage(msg: any, transfer?: ArrayBuffer[]): void;
+    onMessage(cb: (msg: any) => void): void;
+    terminate(): void;
+}
+
+/** Everything the viewer needs from its platform */
+export interface Host {
+    loadImage(name: string): Promise<HostImage>;
+    loadJSON(name: string): Promise<any>;
+    createWorker(): HostWorker;
+    now(): number;
+    renderText?: ((text: string) => HostImage | null) | null;
+}
+
+export interface ViewerOptions {
+    host?: Host;
+    numWorkers?: number;
+}
 
 export const viewer: {
     Viewer: any;
     WorldView: any;
     MapControls: any;
-    Entitiy: any;
+    Entity: any;
     getBufferFromStream: (stream: any) => Promise<Buffer>;
+    defaultHost: () => Host;
+    createNodeHost: (options?: { assetsDir?: string; fetch?: typeof fetch; workerFile?: string }) => Host;
+    createBrowserHost: (options?: { assetsUrl?: string; workerUrl?: string; textureProxy?: string | null }) => Host;
+    createElectronHost: (options?: { assetsDir?: string; workerUrl?: string }) => Host;
 };
 
 export const supportedVersions: versions[];

--- a/lib/headless.js
+++ b/lib/headless.js
@@ -1,4 +1,3 @@
-/* global THREE */
 function safeRequire (path) {
   try {
     return require(path)
@@ -8,16 +7,15 @@ function safeRequire (path) {
 }
 const { spawn } = require('child_process')
 const net = require('net')
-global.THREE = require('three')
-global.Worker = require('worker_threads').Worker
+const THREE = require('three')
 const { createCanvas } = safeRequire('node-canvas-webgl/lib')
 
-const { WorldView, Viewer, getBufferFromStream } = require('../viewer')
+const { WorldView, Viewer, getBufferFromStream, createNodeHost } = require('../viewer')
 
-module.exports = (bot, { viewDistance = 6, output = 'output.mp4', frames = -1, width = 512, height = 512, logFFMPEG = false, jpegOptions }) => {
+module.exports = (bot, { viewDistance = 6, output = 'output.mp4', frames = -1, width = 512, height = 512, logFFMPEG = false, jpegOptions, numWorkers }) => {
   const canvas = createCanvas(width, height)
   const renderer = new THREE.WebGLRenderer({ canvas })
-  const viewer = new Viewer(renderer)
+  const viewer = new Viewer(renderer, { host: createNodeHost(), numWorkers })
 
   if (!viewer.setVersion(bot.version)) {
     return false

--- a/lib/index.js
+++ b/lib/index.js
@@ -62,7 +62,7 @@ socket.on('version', (version) => {
     }
     if (addMesh) {
       if (!botMesh) {
-        botMesh = new Entity('1.16.4', 'player', viewer.scene).mesh
+        botMesh = new Entity('1.16.4', 'player', viewer.scene, {}, viewer.host).mesh
         viewer.scene.add(botMesh)
       }
       new TWEEN.Tween(botMesh.position).to({ x: pos.x, y: pos.y, z: pos.z }, 50).start()

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.33.0",
   "description": "Web based viewer",
   "main": "index.js",
+  "browser": {
+    "./viewer/lib/host/node.js": "./viewer/lib/host/browser.js"
+  },
   "scripts": {
     "jestTest": "jest --verbose --runInBand --forceExit",
     "test": "npm run test",

--- a/test/host.test.js
+++ b/test/host.test.js
@@ -1,0 +1,59 @@
+/* eslint-env jest */
+const path = require('path')
+const { createNodeHost } = require('../viewer/lib/host/node')
+const { loadTexture, loadPixels } = require('../viewer/lib/textures')
+
+describe('node host', () => {
+  const host = createNodeHost({ assetsDir: path.join(__dirname, '../viewer/lib') })
+
+  it('decodes a png into RGBA rows', async () => {
+    const image = await host.loadImage('missing_texture.png')
+    expect(image.width).toBe(16)
+    expect(image.height).toBe(16)
+    expect(image.data).toBeInstanceOf(Uint8Array)
+    expect(image.data.length).toBe(16 * 16 * 4)
+    expect(image.data[3]).toBe(255)
+  })
+
+  it('reads json assets', async () => {
+    const json = await host.loadJSON('entity/entities.json')
+    expect(json.player.geometry).toBeDefined()
+  })
+
+  it('rejects a missing asset', async () => {
+    await expect(host.loadImage('nope.png')).rejects.toThrow()
+  })
+
+  it('meshes on a worker thread', async () => {
+    const worker = host.createWorker()
+    const first = new Promise(resolve => worker.onMessage(resolve))
+    worker.postMessage({ type: 'version', version: '1.16.4' })
+    worker.postMessage({ type: 'dirty', x: 0, y: 0, z: 0, value: false })
+    expect(await first).toEqual({ type: 'sectionFinished', key: '0,0,0' })
+    worker.terminate()
+  })
+})
+
+describe('textures', () => {
+  const host = createNodeHost({ assetsDir: path.join(__dirname, '../viewer/lib') })
+
+  it('builds a nearest-filtered DataTexture that is not flipped', async () => {
+    const THREE = require('three')
+    const texture = await loadTexture(host, 'missing_texture.png')
+    expect(texture).toBeInstanceOf(THREE.DataTexture)
+    expect(texture.image.width).toBe(16)
+    expect(texture.magFilter).toBe(THREE.NearestFilter)
+    expect(texture.flipY).toBe(false)
+  })
+
+  it('caches per host and shares pixels with the texture', async () => {
+    expect(await loadTexture(host, 'missing_texture.png')).toBe(await loadTexture(host, 'missing_texture.png'))
+    expect((await loadTexture(host, 'missing_texture.png')).image.data).toBe((await loadPixels(host, 'missing_texture.png')).data)
+    expect(await loadTexture(createNodeHost(), 'missing_texture.png')).toBe(null)
+  })
+
+  it('resolves null instead of failing when an image is unavailable', async () => {
+    expect(await loadTexture(host, 'nope.png')).toBe(null)
+    expect(await loadPixels(host, 'nope.png')).toBe(null)
+  })
+})

--- a/viewer/README.md
+++ b/viewer/README.md
@@ -8,11 +8,21 @@ Viewer library provides Viewer and WorldView which together make it possible to 
 
 The viewer exposes methods to render a world to a three.js renderer.
 
-#### Viewer(renderer)
+#### Viewer(renderer, options = {})
 
 Build the viewer.
 
 * renderer is a [WebGLRenderer](https://threejs.org/docs/#api/en/renderers/WebGLRenderer) instance
+* options.host is a [host](#hosts); defaults to the browser host on a page, the electron host when `globalThis.isElectron` is set, and the node host otherwise
+* options.numWorkers is the number of mesher workers (default 4)
+
+#### host
+
+the host the viewer loads assets and spawns workers through
+
+#### dispose ()
+
+Removes everything from the scene and terminates the mesher workers.
 
 #### version
 
@@ -87,6 +97,38 @@ Update the world. This need to be called in the animate function, just before th
 #### waitForChunksToRender ()
 
 Returns a promise that resolve once all sections marked dirty have been rendered by the worker threads. Can be used to wait for chunks to 'appear'.
+
+### Hosts
+
+A host is everything the viewer needs from its platform. The rendering code only talks to the host, so the same Viewer runs in a browser, in node under headless-gl or node-canvas-webgl, and in electron.
+
+```js
+{
+  loadImage (name),   // -> Promise<{ width, height, data }>: RGBA bytes, top row first
+  loadJSON (name),    // -> Promise<object>
+  createWorker (),    // -> { postMessage (msg, transfer), onMessage (cb), terminate () }
+  now (),             // -> milliseconds
+  renderText (text)   // -> { width, height, data } or null; optional, draws username labels
+}
+```
+
+`name` is an asset path under `public/` (`textures/1.16.4.png`, `blocksStates/1.16.4.json`) or an http(s) URL (player skins).
+
+#### createNodeHost({ assetsDir, fetch, workerFile })
+
+Reads assets from the prerendered `public/` directory (or the given `assetsDir`), fetches URLs with `fetch`, meshes on `worker_threads`, and draws labels with `canvas` when it is installed. Needs no native module besides the renderer you bring.
+
+#### createBrowserHost({ assetsUrl, workerUrl, textureProxy })
+
+Fetches assets relative to the page (`assetsUrl` prefix), meshes on a Web Worker loaded from `workerUrl` (default `worker.js`), and rewrites `textures.minecraft.net` skin URLs to the `textureProxy` route (default `texture/`, the one `mineflayer` mode serves; `null` to fetch skins directly).
+
+#### createElectronHost({ assetsDir, workerUrl })
+
+Node loaders with the page's Web Worker and canvas, for a renderer with node integration.
+
+#### defaultHost()
+
+The host `Viewer` picks when none is given. Bundlers replace the node host with the browser host through the package's `browser` field.
 
 ### WorldView
 

--- a/viewer/index.js
+++ b/viewer/index.js
@@ -4,5 +4,9 @@ module.exports = {
   MapControls: require('./lib/controls').MapControls,
   Entity: require('./lib/entity/Entity'),
   getBufferFromStream: require('./lib/simpleUtils').getBufferFromStream,
-  supportedVersions: require('./lib/version').supportedVersions
+  supportedVersions: require('./lib/version').supportedVersions,
+  defaultHost: require('./lib/host').defaultHost,
+  createNodeHost: require('./lib/host/node').createNodeHost,
+  createBrowserHost: require('./lib/host/browser').createBrowserHost,
+  createElectronHost: require('./lib/host/electron').createElectronHost
 }

--- a/viewer/lib/entities.js
+++ b/viewer/lib/entities.js
@@ -3,32 +3,23 @@ const TWEEN = require('@tweenjs/tween.js')
 
 const Entity = require('./entity/Entity')
 const { dispose3 } = require('./dispose')
+const { defaultHost } = require('./host')
 
-let createCanvas
-try { ({ createCanvas } = require('canvas')) } catch {}
-
-function getEntityMesh (entity, scene) {
+function getEntityMesh (entity, scene, host) {
   if (entity.name) {
     try {
       const textures = {}
       if (entity.skin) textures.default = entity.skin
       if (entity.cape) textures.cape = entity.cape
       const model = entity.name === 'player' && entity.skinModel === 'slim' ? 'player_slim' : entity.name
-      const e = new Entity('1.16.4', model, scene, textures)
+      const e = new Entity('1.16.4', model, scene, textures, host)
 
-      if (entity.username !== undefined && createCanvas) {
-        const canvas = createCanvas(500, 100)
-
-        const ctx = canvas.getContext('2d')
-        ctx.font = '50pt Arial'
-        ctx.fillStyle = '#000000'
-        ctx.textAlign = 'left'
-        ctx.textBaseline = 'top'
-
-        const txt = entity.username
-        ctx.fillText(txt, 100, 0)
-
-        const tex = new THREE.Texture(canvas)
+      const label = entity.username !== undefined && host.renderText && host.renderText(entity.username)
+      if (label) {
+        const tex = new THREE.DataTexture(label.data, label.width, label.height, THREE.RGBAFormat)
+        tex.magFilter = THREE.LinearFilter
+        tex.minFilter = THREE.LinearFilter
+        tex.flipY = true
         tex.needsUpdate = true
         const spriteMat = new THREE.SpriteMaterial({ map: tex })
         const sprite = new THREE.Sprite(spriteMat)
@@ -97,14 +88,15 @@ function animateWalk (mesh, ticks) {
 }
 
 class Entities {
-  constructor (scene) {
+  constructor (scene, host = defaultHost()) {
     this.scene = scene
+    this.host = host
     this.entities = {}
-    this.lastAnimate = performance.now()
+    this.lastAnimate = host.now()
   }
 
   animate () {
-    const now = performance.now()
+    const now = this.host.now()
     const ticks = (now - this.lastAnimate) / 50
     this.lastAnimate = now
     if (ticks === 0) return
@@ -124,7 +116,7 @@ class Entities {
   update (entity) {
     if (!this.entities[entity.id]) {
       if (!entity.pos) return
-      const mesh = getEntityMesh(entity, this.scene)
+      const mesh = getEntityMesh(entity, this.scene, this.host)
       if (!mesh) return
       this.entities[entity.id] = mesh
       this.scene.add(mesh)

--- a/viewer/lib/entity/Entity.js
+++ b/viewer/lib/entity/Entity.js
@@ -1,9 +1,7 @@
-/* global THREE */
-
+const THREE = require('three')
 const entities = require('./entities.json')
-const { loadTexture } = globalThis.isElectron ? require('../utils.electron.js') : require('../utils')
-let createCanvas
-try { ({ createCanvas } = require('canvas')) } catch {}
+const { defaultHost } = require('../host')
+const { textureFromPixels, loadPixels, loadTexture } = require('../textures')
 
 const elemFaces = {
   up: {
@@ -131,9 +129,6 @@ function addCube (attr, boneId, bone, cube, texWidth = 64, texHeight = 64) {
 }
 
 function applyTexture (material, texture) {
-  texture.magFilter = THREE.NearestFilter
-  texture.minFilter = THREE.NearestFilter
-  texture.flipY = false
   texture.wrapS = THREE.RepeatWrapping
   texture.wrapT = THREE.RepeatWrapping
   material.map = texture
@@ -146,24 +141,15 @@ const legacySkinCopies = [
   [44, 16, -8, 32, 4, 4], [48, 16, -8, 32, 4, 4], [40, 20, 0, 32, 4, 12], [44, 20, -8, 32, 4, 12], [48, 20, -16, 32, 4, 12], [52, 20, -8, 32, 4, 12]
 ]
 
-// RGBA rows of a loaded texture. A DataTexture carries them; an image is drawn once to read them.
-function texturePixels (image) {
-  if (image.data) return image.data
-  const ctx = createCanvas(image.width, image.height).getContext('2d')
-  ctx.drawImage(image, 0, 0)
-  return ctx.getImageData(0, 0, image.width, image.height).data
-}
-
 // Same steps as vanilla's HttpTexture.processLegacySkin. Skins predating 1.8 are 64x32 and
 // the player geometry samples a 64x64 sheet: the left limbs become mirrored copies of the
 // right ones, and an overlay block with no transparency at all was never used as a hat, so
 // its hat rows are dropped. Every skin then gets its base layers forced opaque (head, body
 // row, lower limbs), which is what makes the second layer the only see-through one. Capes are
 // 64x32 by design and never pass through here.
-function prepareSkin (texture) {
-  const image = texture.image
-  if (image.width !== 64 || (image.height !== 32 && image.height !== 64)) return texture
-  const src = texturePixels(image)
+function prepareSkin (image) {
+  if (image.width !== 64 || (image.height !== 32 && image.height !== 64)) return image
+  const src = image.data
   const out = new Uint8Array(64 * 64 * 4)
   out.set(src)
   const at = (x, y) => (y * 64 + x) * 4
@@ -182,12 +168,10 @@ function prepareSkin (texture) {
   for (const [x0, y0, x1, y1] of [[0, 0, 32, 16], [0, 16, 64, 32], [16, 48, 48, 64]]) {
     for (let y = y0; y < y1; y++) for (let x = x0; x < x1; x++) out[at(x, y) + 3] = 255
   }
-  const prepared = new THREE.DataTexture(out, 64, 64, THREE.RGBAFormat)
-  prepared.needsUpdate = true
-  return prepared
+  return { width: 64, height: 64, data: out }
 }
 
-function getMesh (texture, jsonModel, override) {
+function getMesh (texture, jsonModel, override, host) {
   const bones = {}
 
   const geoData = {
@@ -260,13 +244,14 @@ function getMesh (texture, jsonModel, override) {
   // never sees (a player across the server) costs no fetch.
   mesh.onBeforeRender = () => {
     mesh.onBeforeRender = () => {}
+    const apply = texture => { if (texture) applyTexture(material, texture) }
     if (texture) {
-      loadTexture(texture, texture => {
-        applyTexture(material, texture)
-        if (override) loadTexture(override, texture => applyTexture(material, prepareSkin(texture)))
+      loadTexture(host, texture).then(texture => {
+        apply(texture)
+        if (override) loadPixels(host, override).then(pixels => { if (pixels) applyTexture(material, textureFromPixels(prepareSkin(pixels))) })
       })
     } else {
-      loadTexture(override, texture => applyTexture(material, texture))
+      loadTexture(host, override).then(apply)
     }
   }
 
@@ -274,7 +259,7 @@ function getMesh (texture, jsonModel, override) {
 }
 
 class Entity {
-  constructor (version, type, scene, textures = {}) {
+  constructor (version, type, scene, textures = {}, host = defaultHost()) {
     const e = entities[type]
     if (!e) throw new Error(`Unknown entity ${type}`)
 
@@ -283,7 +268,7 @@ class Entity {
       const texture = e.textures[name]
       if (!texture && !textures[name]) continue
       // console.log(JSON.stringify(jsonModel, null, 2))
-      const mesh = getMesh(texture && texture.replace('textures', 'textures/' + version) + '.png', jsonModel, textures[name])
+      const mesh = getMesh(texture && texture.replace('textures', 'textures/' + version) + '.png', jsonModel, textures[name], host)
       /* const skeletonHelper = new THREE.SkeletonHelper( mesh )
       skeletonHelper.material.linewidth = 2
       scene.add( skeletonHelper ) */

--- a/viewer/lib/host/browser.js
+++ b/viewer/lib/host/browser.js
@@ -1,0 +1,79 @@
+/* global Worker Image document fetch performance */
+
+function isUrl (name) {
+  return /^https?:\/\//.test(name)
+}
+
+// Host for browsers: assets are fetched relative to the page (the express
+// server mounts public/ there), meshing runs on a Web Worker built from
+// viewer/lib/worker.js, and text is drawn on a 2D canvas.
+//
+// textures.minecraft.net sends no CORS headers, so player skins are fetched
+// through the server's proxy route (lib/mineflayer.js) instead; textureProxy
+// is that route's prefix, or null to fetch skins directly.
+function createBrowserHost ({ assetsUrl = '', workerUrl = 'worker.js', textureProxy = 'texture/' } = {}) {
+  function resolve (name) {
+    if (!isUrl(name)) return assetsUrl + name
+    if (textureProxy !== null) return name.replace(/^https?:\/\/textures\.minecraft\.net\/texture\//, textureProxy)
+    return name
+  }
+
+  return {
+    loadImage (name) {
+      const url = resolve(name)
+      return new Promise((resolve, reject) => {
+        const img = new Image()
+        if (isUrl(url)) img.crossOrigin = 'anonymous'
+        img.onload = () => resolve(imagePixels(img))
+        img.onerror = () => reject(new Error(`${url} failed to load`))
+        img.src = url
+      })
+    },
+
+    async loadJSON (name) {
+      const url = resolve(name)
+      const res = await fetch(url)
+      if (!res.ok) throw new Error(`${url}: ${res.status}`)
+      return res.json()
+    },
+
+    createWorker () {
+      const worker = new Worker(workerUrl)
+      return {
+        postMessage: (msg, transfer) => worker.postMessage(msg, transfer),
+        onMessage: (cb) => { worker.onmessage = ({ data }) => cb(data) },
+        terminate: () => worker.terminate()
+      }
+    },
+
+    now: () => performance.now(),
+
+    renderText (text) {
+      const canvas = document.createElement('canvas')
+      canvas.width = 500
+      canvas.height = 100
+      const ctx = canvas.getContext('2d')
+      ctx.font = '50pt Arial'
+      ctx.fillStyle = '#000000'
+      ctx.textAlign = 'left'
+      ctx.textBaseline = 'top'
+      ctx.fillText(text, 100, 0)
+      return imagePixels(canvas)
+    }
+  }
+}
+
+// RGBA rows of an image or canvas, top row first
+function imagePixels (source) {
+  const width = source.naturalWidth || source.width
+  const height = source.naturalHeight || source.height
+  const canvas = document.createElement('canvas')
+  canvas.width = width
+  canvas.height = height
+  const ctx = canvas.getContext('2d')
+  ctx.drawImage(source, 0, 0)
+  const image = ctx.getImageData(0, 0, width, height)
+  return { width, height, data: new Uint8Array(image.data.buffer) }
+}
+
+module.exports = { createBrowserHost }

--- a/viewer/lib/host/electron.js
+++ b/viewer/lib/host/electron.js
@@ -1,0 +1,20 @@
+const { createNodeHost } = require('./node')
+const { createBrowserHost } = require('./browser')
+
+// Host for an electron renderer with node integration: assets come off disk
+// like in node, while meshing and text use the page's Web Worker and canvas.
+// workerUrl must point at a script that loads viewer/lib/worker.js (see
+// examples/electron/client/worker.js).
+function createElectronHost ({ assetsDir, workerUrl = 'worker.js' } = {}) {
+  const node = createNodeHost({ assetsDir })
+  const browser = createBrowserHost({ workerUrl, textureProxy: null })
+  return {
+    loadImage: node.loadImage,
+    loadJSON: node.loadJSON,
+    createWorker: browser.createWorker,
+    now: browser.now,
+    renderText: browser.renderText
+  }
+}
+
+module.exports = { createElectronHost }

--- a/viewer/lib/host/index.js
+++ b/viewer/lib/host/index.js
@@ -1,0 +1,21 @@
+// A host is everything the viewer needs from its platform, so the rendering
+// code has no idea whether it runs in a browser, in node under headless-gl or
+// in electron. Bundlers swap ./node for ./browser through the package.json
+// "browser" field.
+//
+//   loadImage(name) -> Promise<{ width, height, data }>  RGBA bytes, top row first
+//   loadJSON(name) -> Promise<object>
+//   createWorker() -> { postMessage(msg, transfer), onMessage(cb), terminate() }
+//   now() -> milliseconds
+//   renderText(text) -> { width, height, data } | null   (optional: username sprites)
+//
+// name is an asset path under public/ ("textures/1.16.4.png",
+// "blocksStates/1.16.4.json") or an http(s) URL (player skins).
+
+function defaultHost () {
+  if (globalThis.isElectron) return require('./electron').createElectronHost()
+  if (typeof window !== 'undefined') return require('./browser').createBrowserHost()
+  return require('./node').createNodeHost()
+}
+
+module.exports = { defaultHost }

--- a/viewer/lib/host/node.js
+++ b/viewer/lib/host/node.js
@@ -1,0 +1,62 @@
+const fs = require('fs')
+const path = require('path')
+const { Worker } = require('worker_threads')
+const { PNG } = require('pngjs')
+
+let createCanvas
+try { ({ createCanvas } = require('canvas')) } catch {}
+
+function isUrl (name) {
+  return /^https?:\/\//.test(name)
+}
+
+// Host for node: assets are read from the prerendered public/ directory (or
+// any http(s) URL), meshing runs on worker_threads, and username sprites are
+// drawn with node-canvas when it is installed. Nothing here needs a GL canvas,
+// so it pairs with headless-gl, node-canvas-webgl or any other renderer.
+function createNodeHost ({ assetsDir = path.resolve(__dirname, '../../../public'), fetch = globalThis.fetch, workerFile = path.join(__dirname, '../worker.js') } = {}) {
+  async function readAsset (name) {
+    if (!isUrl(name)) return fs.promises.readFile(path.resolve(assetsDir, name))
+    const res = await fetch(name)
+    if (!res.ok) throw new Error(`${name}: ${res.status}`)
+    return Buffer.from(await res.arrayBuffer())
+  }
+
+  return {
+    async loadImage (name) {
+      const png = PNG.sync.read(await readAsset(name))
+      return { width: png.width, height: png.height, data: new Uint8Array(png.data.buffer, png.data.byteOffset, png.data.byteLength) }
+    },
+
+    async loadJSON (name) {
+      return JSON.parse((await readAsset(name)).toString('utf8'))
+    },
+
+    createWorker () {
+      const worker = new Worker(workerFile)
+      return {
+        postMessage: (msg, transfer) => worker.postMessage(msg, transfer),
+        onMessage: (cb) => worker.on('message', cb),
+        terminate: () => worker.terminate()
+      }
+    },
+
+    now: () => performance.now(),
+
+    renderText: createCanvas ? (text) => renderText(createCanvas, text) : null
+  }
+}
+
+function renderText (createCanvas, text) {
+  const canvas = createCanvas(500, 100)
+  const ctx = canvas.getContext('2d')
+  ctx.font = '50pt Arial'
+  ctx.fillStyle = '#000000'
+  ctx.textAlign = 'left'
+  ctx.textBaseline = 'top'
+  ctx.fillText(text, 100, 0)
+  const image = ctx.getImageData(0, 0, canvas.width, canvas.height)
+  return { width: image.width, height: image.height, data: new Uint8Array(image.data.buffer) }
+}
+
+module.exports = { createNodeHost, renderText }

--- a/viewer/lib/textures.js
+++ b/viewer/lib/textures.js
@@ -1,0 +1,38 @@
+const THREE = require('three')
+
+// Per-host caches: a host is created per platform or per viewer, so textures
+// it loaded are shared by everything rendering through it
+const pixelCaches = new WeakMap()
+const textureCaches = new WeakMap()
+
+function cache (caches, host) {
+  let c = caches.get(host)
+  if (!c) caches.set(host, c = new Map())
+  return c
+}
+
+// Minecraft textures are pixel art sampled with the image's top row at v = 0
+function textureFromPixels ({ width, height, data }) {
+  const texture = new THREE.DataTexture(data, width, height, THREE.RGBAFormat)
+  texture.magFilter = THREE.NearestFilter
+  texture.minFilter = THREE.NearestFilter
+  texture.flipY = false
+  texture.needsUpdate = true
+  return texture
+}
+
+// Resolve to null when the image can't be loaded (a skin URL that 404s, an
+// offline-mode server), so callers keep whatever they were showing
+function loadPixels (host, name) {
+  const c = cache(pixelCaches, host)
+  if (!c.has(name)) c.set(name, host.loadImage(name).catch(() => null))
+  return c.get(name)
+}
+
+function loadTexture (host, name) {
+  const c = cache(textureCaches, host)
+  if (!c.has(name)) c.set(name, loadPixels(host, name).then(pixels => pixels && textureFromPixels(pixels)))
+  return c.get(name)
+}
+
+module.exports = { textureFromPixels, loadPixels, loadTexture }

--- a/viewer/lib/utils.electron.js
+++ b/viewer/lib/utils.electron.js
@@ -1,18 +1,20 @@
-const THREE = require('three')
-const path = require('path')
+// Deprecated: the viewer loads through a host now (see ./host). Kept for code
+// that imported these loaders directly.
+const { createElectronHost } = require('./host/electron')
+const { loadTexture: load } = require('./textures')
 
-const textureCache = {}
+let host
+function getHost () {
+  if (!host) host = createElectronHost()
+  return host
+}
+
 function loadTexture (texture, cb) {
-  if (textureCache[texture]) return cb(textureCache[texture])
-  const url = /^https?:\/\//.test(texture) ? texture : path.resolve(__dirname, '../../public/' + texture)
-  new THREE.TextureLoader().load(url, loaded => {
-    textureCache[texture] = loaded
-    cb(loaded)
-  }, undefined, () => {})
+  load(getHost(), texture).then(texture => { if (texture) cb(texture) })
 }
 
 function loadJSON (json, cb) {
-  cb(require(path.resolve(__dirname, '../../public/' + json)))
+  getHost().loadJSON(json).then(cb)
 }
 
 module.exports = { loadTexture, loadJSON }

--- a/viewer/lib/utils.js
+++ b/viewer/lib/utils.js
@@ -1,41 +1,20 @@
-const { PNG } = require('pngjs')
-const THREE = require('three')
-const path = require('path')
-const fs = require('fs')
+// Deprecated: the viewer loads through a host now (see ./host). Kept for code
+// that imported these loaders directly.
+const { defaultHost } = require('./host')
+const { loadTexture: load } = require('./textures')
 
-const textureCache = {}
-
-// bundled textures are files under public/; player skins are http(s) URLs
-async function readPng (texture) {
-  if (/^https?:\/\//.test(texture)) {
-    const res = await fetch(texture)
-    if (!res.ok) throw new Error(`${texture}: ${res.status}`)
-    return PNG.sync.read(Buffer.from(await res.arrayBuffer()))
-  }
-  return PNG.sync.read(await fs.promises.readFile(path.resolve(__dirname, '../../public/' + texture)))
+let host
+function getHost () {
+  if (!host) host = defaultHost()
+  return host
 }
 
-// todo not ideal, export different functions for browser and node
 function loadTexture (texture, cb) {
-  if (process.platform === 'browser') {
-    return require('./utils.web').loadTexture(texture, cb)
-  }
-
-  if (!textureCache[texture]) {
-    textureCache[texture] = readPng(texture).then(png => {
-      const tex = new THREE.DataTexture(new Uint8Array(png.data), png.width, png.height, THREE.RGBAFormat)
-      tex.needsUpdate = true
-      return tex
-    })
-  }
-  textureCache[texture].then(cb).catch(() => {})
+  load(getHost(), texture).then(texture => { if (texture) cb(texture) })
 }
 
 function loadJSON (json, cb) {
-  if (process.platform === 'browser') {
-    return require('./utils.web').loadJSON(json, cb)
-  }
-  cb(require(path.resolve(__dirname, '../../public/' + json)))
+  getHost().loadJSON(json).then(cb)
 }
 
 module.exports = { loadTexture, loadJSON }

--- a/viewer/lib/utils.web.js
+++ b/viewer/lib/utils.web.js
@@ -1,30 +1,20 @@
-/* global XMLHttpRequest */
-const THREE = require('three')
+// Deprecated: the viewer loads through a host now (see ./host). Kept for code
+// that imported these loaders directly.
+const { createBrowserHost } = require('./host/browser')
+const { loadTexture: load } = require('./textures')
 
-const textureCache = {}
-function loadTexture (texture, cb) {
-  if (!textureCache[texture]) {
-    // textures.minecraft.net sends no CORS headers: player skins go through the
-    // server's proxy route (lib/mineflayer.js)
-    const url = texture.replace(/^https?:\/\/textures\.minecraft\.net\/texture\//, 'texture/')
-    textureCache[texture] = new Promise(resolve => new THREE.TextureLoader().load(url, resolve, undefined, () => {}))
-  }
-  textureCache[texture].then(cb)
+let host
+function getHost () {
+  if (!host) host = createBrowserHost()
+  return host
 }
 
-function loadJSON (url, callback) {
-  const xhr = new XMLHttpRequest()
-  xhr.open('GET', url, true)
-  xhr.responseType = 'json'
-  xhr.onload = function () {
-    const status = xhr.status
-    if (status === 200) {
-      callback(xhr.response)
-    } else {
-      throw new Error(url + ' not found')
-    }
-  }
-  xhr.send()
+function loadTexture (texture, cb) {
+  load(getHost(), texture).then(texture => { if (texture) cb(texture) })
+}
+
+function loadJSON (json, cb) {
+  getHost().loadJSON(json).then(cb)
 }
 
 module.exports = { loadTexture, loadJSON }

--- a/viewer/lib/viewer.js
+++ b/viewer/lib/viewer.js
@@ -5,9 +5,14 @@ const { Entities } = require('./entities')
 const { Primitives } = require('./primitives')
 const { getVersion } = require('./version')
 const { Vec3 } = require('vec3')
+const { defaultHost } = require('./host')
 
 class Viewer {
-  constructor (renderer, numWorkers) {
+  constructor (renderer, options = {}) {
+    if (typeof options === 'number') options = { numWorkers: options }
+    const { host = defaultHost(), numWorkers } = options
+    this.host = host
+
     this.scene = new THREE.Scene()
     this.scene.background = new THREE.Color('lightblue')
 
@@ -22,8 +27,8 @@ class Viewer {
     const size = renderer.getSize(new THREE.Vector2())
     this.camera = new THREE.PerspectiveCamera(75, size.x / size.y, 0.1, 1000)
 
-    this.world = new WorldRenderer(this.scene, numWorkers)
-    this.entities = new Entities(this.scene)
+    this.world = new WorldRenderer(this.scene, { host, numWorkers })
+    this.entities = new Entities(this.scene, host)
     this.primitives = new Primitives(this.scene, this.camera)
 
     this.domElement = renderer.domElement
@@ -35,6 +40,12 @@ class Viewer {
     this.world.resetWorld()
     this.entities.clear()
     this.primitives.clear()
+  }
+
+  dispose () {
+    this.entities.clear()
+    this.primitives.clear()
+    this.world.dispose()
   }
 
   setVersion (version) {

--- a/viewer/lib/worldrenderer.js
+++ b/viewer/lib/worldrenderer.js
@@ -1,16 +1,19 @@
-/* global Worker */
 const THREE = require('three')
 const Vec3 = require('vec3').Vec3
-const { loadTexture, loadJSON } = globalThis.isElectron ? require('./utils.electron.js') : require('./utils')
 const { EventEmitter } = require('events')
 const { dispose3 } = require('./dispose')
+const { defaultHost } = require('./host')
+const { loadTexture } = require('./textures')
 
 function mod (x, n) {
   return ((x % n) + n) % n
 }
 
 class WorldRenderer {
-  constructor (scene, numWorkers = 4) {
+  constructor (scene, options = {}) {
+    if (typeof options === 'number') options = { numWorkers: options }
+    const { host = defaultHost(), numWorkers = 4 } = options
+    this.host = host
     this.sectionMeshs = {}
     this.active = false
     this.version = undefined
@@ -35,44 +38,46 @@ class WorldRenderer {
 
     this.workers = []
     for (let i = 0; i < numWorkers; i++) {
-      // Node environement needs an absolute path, but browser needs the url of the file
-      let src = __dirname
-      if (typeof window !== 'undefined') src = 'worker.js'
-      else src += '/worker.js'
-
-      const worker = new Worker(src)
-      worker.onmessage = ({ data }) => {
-        if (data.type === 'geometry') {
-          let mesh = this.sectionMeshs[data.key]
-          if (mesh) {
-            this.scene.remove(mesh)
-            dispose3(mesh)
-            delete this.sectionMeshs[data.key]
-          }
-
-          const chunkCoords = data.key.split(',')
-          if (!this.loadedChunks[chunkCoords[0] + ',' + chunkCoords[2]]) return
-
-          const geometry = new THREE.BufferGeometry()
-          geometry.setAttribute('position', new THREE.BufferAttribute(data.geometry.positions, 3))
-          geometry.setAttribute('normal', new THREE.BufferAttribute(data.geometry.normals, 3))
-          geometry.setAttribute('color', new THREE.BufferAttribute(data.geometry.colors, 3))
-          geometry.setAttribute('uv', new THREE.BufferAttribute(data.geometry.uvs, 2))
-          geometry.setAttribute('animation', new THREE.BufferAttribute(data.geometry.animations, 2))
-          geometry.setIndex(data.geometry.indices)
-
-          mesh = new THREE.Mesh(geometry, this.material)
-          mesh.position.set(data.geometry.sx, data.geometry.sy, data.geometry.sz)
-          this.sectionMeshs[data.key] = mesh
-          this.scene.add(mesh)
-        } else if (data.type === 'sectionFinished') {
-          this.sectionsOutstanding.delete(data.key)
-          this.renderUpdateEmitter.emit('update')
-        }
-      }
-      if (worker.on) worker.on('message', (data) => { worker.onmessage({ data }) })
+      const worker = host.createWorker()
+      worker.onMessage((data) => this.onWorkerMessage(data))
       this.workers.push(worker)
     }
+  }
+
+  onWorkerMessage (data) {
+    if (data.type === 'geometry') {
+      let mesh = this.sectionMeshs[data.key]
+      if (mesh) {
+        this.scene.remove(mesh)
+        dispose3(mesh)
+        delete this.sectionMeshs[data.key]
+      }
+
+      const chunkCoords = data.key.split(',')
+      if (!this.loadedChunks[chunkCoords[0] + ',' + chunkCoords[2]]) return
+
+      const geometry = new THREE.BufferGeometry()
+      geometry.setAttribute('position', new THREE.BufferAttribute(data.geometry.positions, 3))
+      geometry.setAttribute('normal', new THREE.BufferAttribute(data.geometry.normals, 3))
+      geometry.setAttribute('color', new THREE.BufferAttribute(data.geometry.colors, 3))
+      geometry.setAttribute('uv', new THREE.BufferAttribute(data.geometry.uvs, 2))
+      geometry.setAttribute('animation', new THREE.BufferAttribute(data.geometry.animations, 2))
+      geometry.setIndex(data.geometry.indices)
+
+      mesh = new THREE.Mesh(geometry, this.material)
+      mesh.position.set(data.geometry.sx, data.geometry.sy, data.geometry.sz)
+      this.sectionMeshs[data.key] = mesh
+      this.scene.add(mesh)
+    } else if (data.type === 'sectionFinished') {
+      this.sectionsOutstanding.delete(data.key)
+      this.renderUpdateEmitter.emit('update')
+    }
+  }
+
+  dispose () {
+    this.resetWorld()
+    for (const worker of this.workers) worker.terminate()
+    this.workers = []
   }
 
   resetWorld () {
@@ -99,30 +104,25 @@ class WorldRenderer {
   }
 
   updateTexturesData () {
-    loadTexture(this.texturesDataUrl || `textures/${this.assetsVersion}.png`, texture => {
-      texture.magFilter = THREE.NearestFilter
-      texture.minFilter = THREE.NearestFilter
-      texture.flipY = false
+    loadTexture(this.host, this.texturesDataUrl || `textures/${this.assetsVersion}.png`).then(texture => {
+      if (!texture) return
       this.uniforms.tileHeight.value = 16 / texture.image.height
       this.material.map = texture
       this.material.needsUpdate = true
     })
 
-    const loadBlockStates = () => {
-      return new Promise(resolve => {
-        if (this.blockStatesData) return resolve(this.blockStatesData)
-        return loadJSON(`blocksStates/${this.assetsVersion}.json`, resolve)
-      })
-    }
-    loadBlockStates().then((blockStates) => {
+    const blockStates = this.blockStatesData
+      ? Promise.resolve(this.blockStatesData)
+      : this.host.loadJSON(`blocksStates/${this.assetsVersion}.json`)
+    blockStates.then((json) => {
       for (const worker of this.workers) {
-        worker.postMessage({ type: 'blockStates', json: blockStates })
+        worker.postMessage({ type: 'blockStates', json })
       }
     })
   }
 
   update () {
-    this.uniforms.time.value = performance.now() / 50
+    this.uniforms.time.value = this.host.now() / 50
   }
 
   addColumn (x, z, chunk) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,12 +37,7 @@ const indexConfig = {
     }),
     new webpack.ProvidePlugin({
       Buffer: ['buffer', 'Buffer']
-    }),
-    new webpack.NormalModuleReplacementPlugin(
-      // eslint-disable-next-line
-      /viewer[\/|\\]lib[\/|\\]utils/,
-      './utils.web.js'
-    )
+    })
     // new BundleAnalyzerPlugin()
   ],
   externals: [


### PR DESCRIPTION
Part of a stack: #490 → #494 → #495 → #496 → #497. Each PR is based on the one below it (base branches `player-skins`, `host-1-no-canvas`, `host-2-host-object`, `host-3-mesher` are copies pushed to this repo for that purpose). Merge order is bottom-up; after each merge, retarget the next PR to master and delete its base branch copy.

The viewer picked its platform at require time in four different ways: a webpack module replacement swapped `utils.js` for `utils.web.js`, `utils.js` re-dispatched on `process.platform`, `worldrenderer.js` and `Entity.js` branched on `globalThis.isElectron`, and the worker path came from sniffing `window`. Each headless consumer then had to set `global.THREE` and `global.Worker` and carry node-canvas for texture decoding, and anything outside those three cases (headless-gl with a stub canvas, tests) had no hook at all.

Everything the rendering code needs from the platform is now one object, the **host**, passed to `Viewer` and on to `WorldRenderer`, `Entities` and `Entity`:

```js
loadImage(name)   // -> Promise<{ width, height, data }>  RGBA rows, top row first
loadJSON(name)    // -> Promise<object>
createWorker()    // -> { postMessage, onMessage, terminate }
now()             // -> ms
renderText(text)  // -> { width, height, data } | null   (optional: username sprites)
```

- textures arrive as pixels on every platform and the core builds the `DataTexture` itself, so the skin pipeline from #490 no longer needs a canvas to read an image back, and the browser, node and electron loaders differ only in where the bytes come from
- three hosts ship (`createNodeHost`, `createBrowserHost`, `createElectronHost`) and `Viewer` defaults to the one matching the environment, so `new Viewer(renderer)` keeps working everywhere it did
- bundlers pick the browser host through the package.json `browser` field instead of the webpack plugin (works with webpack, esbuild, vite)
- `utils.js`, `utils.web.js`, `utils.electron.js` stay as deprecated wrappers over the default host
- `lib/headless.js` and the core example no longer set globals; `Viewer.dispose()` terminates the workers
- `test/host.test.js` covers the node host, the texture cache and the null-on-failure contract
- docs in `viewer/README.md` (Hosts section) and `index.d.ts`

Verified: the existing puppeteer test (browser host), and a headless-gl render with a stub canvas and no node-canvas installed, which is how the MC Chat backend consumes the viewer.

