### PR TITLE
Keep the DOM out of the viewer core

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -38,11 +38,17 @@ window.addEventListener('resize', () => {
 
 socket.on('version', (version) => {
   if (!viewer.setVersion(version)) {
+    window.alert(`${version} is not supported`)
     return false
   }
 
   firstPositionUpdate = true
   viewer.listen(socket)
+  renderer.domElement.addEventListener('pointerdown', (evt) => {
+    const x = (evt.clientX / renderer.domElement.clientWidth) * 2 - 1
+    const y = -(evt.clientY / renderer.domElement.clientHeight) * 2 + 1
+    socket.emit('mouseClick', { ...viewer.pickRay(x, y), button: evt.button })
+  })
 
   let botMesh
   socket.on('position', ({ pos, addMesh, yaw, pitch }) => {

--- a/viewer/README.md
+++ b/viewer/README.md
@@ -87,8 +87,20 @@ the emitter should emit these events:
 * loadChunk({x, z, chunk}) ; add a column
 * unloadChunk({x, z}) ; removes a column
 * blockUpdate({pos, stateId}) ; update a block
-it also listen to these events:
-* mouseClick({ origin, direction, button })
+
+The WorldView on the other end listens for mouseClick({ origin, direction, button }) and raycasts it into the world; the page emits it from its own pointer events with `pickRay`:
+
+```js
+renderer.domElement.addEventListener('pointerdown', (evt) => {
+  const x = (evt.clientX / renderer.domElement.clientWidth) * 2 - 1
+  const y = -(evt.clientY / renderer.domElement.clientHeight) * 2 + 1
+  emitter.emit('mouseClick', { ...viewer.pickRay(x, y), button: evt.button })
+})
+```
+
+#### pickRay (x, y)
+
+The camera ray through a point of the view, x and y in [-1, 1] with right and up positive. Returns { origin, direction }.
 
 #### update ()
 

--- a/viewer/lib/controls.js
+++ b/viewer/lib/controls.js
@@ -1,4 +1,5 @@
 /* eslint-disable */
+const THREE = require('three')
 // Similar to THREE MapControls with more Minecraft-like
 // controls.
 // Defaults:

--- a/viewer/lib/primitives.js
+++ b/viewer/lib/primitives.js
@@ -2,10 +2,10 @@ const THREE = require('three')
 const { MeshLine, MeshLineMaterial } = require('three.meshline')
 const { dispose3 } = require('./dispose')
 
-function getMesh (primitive, camera) {
+function getMesh (primitive, camera, size) {
   if (primitive.type === 'line') {
     const color = primitive.color ? primitive.color : 0xff0000
-    const resolution = new THREE.Vector2(window.innerWidth / camera.zoom, window.innerHeight / camera.zoom)
+    const resolution = new THREE.Vector2(size.x / camera.zoom, size.y / camera.zoom)
     const material = new MeshLineMaterial({ color, resolution, sizeAttenuation: false, lineWidth: 8 })
 
     const points = []
@@ -48,9 +48,10 @@ function getMesh (primitive, camera) {
 }
 
 class Primitives {
-  constructor (scene, camera) {
+  constructor (scene, camera, getSize) {
     this.scene = scene
     this.camera = camera
+    this.getSize = getSize
     this.primitives = {}
   }
 
@@ -69,7 +70,7 @@ class Primitives {
       delete this.primitives[primitive.id]
     }
 
-    const mesh = getMesh(primitive, this.camera)
+    const mesh = getMesh(primitive, this.camera, this.getSize())
     if (!mesh) return
     this.primitives[primitive.id] = mesh
     this.scene.add(mesh)

--- a/viewer/lib/viewer.js
+++ b/viewer/lib/viewer.js
@@ -29,7 +29,7 @@ class Viewer {
 
     this.world = new WorldRenderer(this.scene, { host, numWorkers })
     this.entities = new Entities(this.scene, host)
-    this.primitives = new Primitives(this.scene, this.camera)
+    this.primitives = new Primitives(this.scene, this.camera, () => renderer.getSize(new THREE.Vector2()))
 
     this.domElement = renderer.domElement
     this.playerHeight = 1.6
@@ -51,9 +51,7 @@ class Viewer {
   setVersion (version) {
     const assetsVersion = getVersion(version)
     if (assetsVersion === null) {
-      const msg = `${version} is not supported`
-      window.alert(msg)
-      console.log(msg)
+      console.log(`${version} is not supported`)
       return false
     }
     console.log(`Using version: ${version} (assets: ${assetsVersion})`)
@@ -113,16 +111,14 @@ class Viewer {
     emitter.on('blockUpdate', ({ pos, stateId }) => {
       this.setBlockStateId(new Vec3(pos.x, pos.y, pos.z), stateId)
     })
+  }
 
-    this.domElement.addEventListener('pointerdown', (evt) => {
-      const raycaster = new THREE.Raycaster()
-      const mouse = new THREE.Vector2()
-      mouse.x = (evt.clientX / this.domElement.clientWidth) * 2 - 1
-      mouse.y = -(evt.clientY / this.domElement.clientHeight) * 2 + 1
-      raycaster.setFromCamera(mouse, this.camera)
-      const ray = raycaster.ray
-      emitter.emit('mouseClick', { origin: ray.origin, direction: ray.direction, button: evt.button })
-    })
+  // The camera ray through a point of the view, x and y in [-1, 1] (right and
+  // up positive). What a click handler emits as mouseClick to the WorldView.
+  pickRay (x, y) {
+    const raycaster = new THREE.Raycaster()
+    raycaster.setFromCamera(new THREE.Vector2(x, y), this.camera)
+    return { origin: raycaster.ray.origin, direction: raycaster.ray.direction }
   }
 
   update () {


### PR DESCRIPTION
Part of a stack: #490 → #494 → #495 → #496 → #497. Each PR is based on the one below it (base branches `player-skins`, `host-1-no-canvas`, `host-2-host-object`, `host-3-mesher` are copies pushed to this repo for that purpose). Merge order is bottom-up; after each merge, retarget the next PR to master and delete its base branch copy.

`Viewer` alerted through `window` on an unsupported version, wired `pointerdown` on the renderer's element inside `listen()`, and line primitives read `window.innerWidth`, so a headless host needed a DOM shim for all three.

- the version check just returns false; the browser client alerts
- clicks are the page's business: `Viewer.pickRay(x, y)` returns the camera ray for a point of the view and `lib/index.js` emits `mouseClick` from its own pointer events (documented in `viewer/README.md`)
- primitives size their lines from the renderer
- `MapControls` requires `three` instead of expecting a global

