### PR TITLE
Make the node viewer loadable without node-canvas

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "compression": "^1.7.4",
     "express": "^4.17.1",
     "minecraft-data": "^3.0.0",
+    "pngjs": "^7.0.0",
     "prismarine-block": "^1.7.3",
     "prismarine-chunk": "^1.22.0",
     "prismarine-world": "^3.3.1",

--- a/viewer/lib/entities.js
+++ b/viewer/lib/entities.js
@@ -4,7 +4,8 @@ const TWEEN = require('@tweenjs/tween.js')
 const Entity = require('./entity/Entity')
 const { dispose3 } = require('./dispose')
 
-const { createCanvas } = require('canvas')
+let createCanvas
+try { ({ createCanvas } = require('canvas')) } catch {}
 
 function getEntityMesh (entity, scene) {
   if (entity.name) {
@@ -15,7 +16,7 @@ function getEntityMesh (entity, scene) {
       const model = entity.name === 'player' && entity.skinModel === 'slim' ? 'player_slim' : entity.name
       const e = new Entity('1.16.4', model, scene, textures)
 
-      if (entity.username !== undefined) {
+      if (entity.username !== undefined && createCanvas) {
         const canvas = createCanvas(500, 100)
 
         const ctx = canvas.getContext('2d')

--- a/viewer/lib/utils.js
+++ b/viewer/lib/utils.js
@@ -1,31 +1,34 @@
-function safeRequire (path) {
-  try {
-    return require(path)
-  } catch (e) {
-    return {}
-  }
-}
-const { loadImage } = safeRequire('node-canvas-webgl/lib')
+const { PNG } = require('pngjs')
 const THREE = require('three')
 const path = require('path')
+const fs = require('fs')
 
 const textureCache = {}
+
+// bundled textures are files under public/; player skins are http(s) URLs
+async function readPng (texture) {
+  if (/^https?:\/\//.test(texture)) {
+    const res = await fetch(texture)
+    if (!res.ok) throw new Error(`${texture}: ${res.status}`)
+    return PNG.sync.read(Buffer.from(await res.arrayBuffer()))
+  }
+  return PNG.sync.read(await fs.promises.readFile(path.resolve(__dirname, '../../public/' + texture)))
+}
+
 // todo not ideal, export different functions for browser and node
 function loadTexture (texture, cb) {
   if (process.platform === 'browser') {
     return require('./utils.web').loadTexture(texture, cb)
   }
 
-  if (textureCache[texture]) {
-    cb(textureCache[texture])
-  } else {
-    // bundled textures are files under public/; player skins are http(s) URLs
-    const src = /^https?:\/\//.test(texture) ? texture : path.resolve(__dirname, '../../public/' + texture)
-    loadImage(src).then(image => {
-      textureCache[texture] = new THREE.CanvasTexture(image)
-      cb(textureCache[texture])
-    }).catch(() => {})
+  if (!textureCache[texture]) {
+    textureCache[texture] = readPng(texture).then(png => {
+      const tex = new THREE.DataTexture(new Uint8Array(png.data), png.width, png.height, THREE.RGBAFormat)
+      tex.needsUpdate = true
+      return tex
+    })
   }
+  textureCache[texture].then(cb).catch(() => {})
 }
 
 function loadJSON (json, cb) {

--- a/viewer/lib/viewer.js
+++ b/viewer/lib/viewer.js
@@ -7,7 +7,7 @@ const { getVersion } = require('./version')
 const { Vec3 } = require('vec3')
 
 class Viewer {
-  constructor (renderer) {
+  constructor (renderer, numWorkers) {
     this.scene = new THREE.Scene()
     this.scene.background = new THREE.Color('lightblue')
 
@@ -22,7 +22,7 @@ class Viewer {
     const size = renderer.getSize(new THREE.Vector2())
     this.camera = new THREE.PerspectiveCamera(75, size.x / size.y, 0.1, 1000)
 
-    this.world = new WorldRenderer(this.scene)
+    this.world = new WorldRenderer(this.scene, numWorkers)
     this.entities = new Entities(this.scene)
     this.primitives = new Primitives(this.scene, this.camera)
 


### PR DESCRIPTION
Part of native stack #502 (#498 → #499 → #500 → #501), built on top of #490 whose in-repo copy branch `player-skins` is the stack's trunk. Once #490 merges, retarget #498 to `master` and delete the copy branch; the stack handles the rest. First of a four-PR series that gives the viewer one platform seam so browser, node and electron rendering share the same core.

Headless consumers hit two hard requires on the `canvas` native module even when they bring their own GL context: `entities.js` needs it for username sprites and `utils.js` loaded textures through node-canvas-webgl's `loadImage`. `canvas` builds from source whenever a prebuilt is missing for the running node ABI, which makes it the most fragile part of a headless install.

- `canvas` is required optionally (username sprites are skipped without it)
- textures decode with `pngjs` into a `THREE.DataTexture`, so `Viewer` and `WorldView` work with just headless-gl
- `Viewer` passes `numWorkers` through to `WorldRenderer`, since a memory-capped headless process wants one mesher rather than four

The browser bundle is unaffected: both paths were already node-only. This is what the MC Chat backend has been running from a fork.


