### PR TITLE
headless: a recording handle with stop(), wall-clock frame pacing and a ready wait

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,11 +117,18 @@ const { headless } = require('prismarine-viewer')
 
 Options:
 * `viewDistance` view radius, in chunks, default: `6`
-* `output` the output file or a `host:port` address to stream to, default: `output.mp4`
-* `frames` number of frames to record, `-1` for infinite, default: `200`
+* `output` the output file (`.mp4`), an `rtmp://` stream or a `host:port` address to stream length-prefixed JPEG frames to, default: `output.mp4`
+* `frames` number of frames to record, `-1` for infinite, default: `-1`
+* `fps` frames per second, default: `20`; frames are paced on the wall clock so the video plays at real speed
 * `width` the width of a frame, default: `512`
 * `height` the height of a frame, default: `512`
 * `numWorkers` mesher worker threads, default: `4`
+
+Returns `false` when the bot's version has no assets, otherwise a recording handle:
+* `stop()` finish the recording: closes the output (ffmpeg then writes the mp4 index), waits for it and frees the GL context. Called for you when `frames` is reached, the bot ends or the output goes away.
+* `ready` promise for the first frame: the block atlas and the sections around the bot are rendered before anything is written, so the video does not open on blank sky
+* `canvas` the node-canvas-webgl canvas, e.g. `canvas.toBuffer('image/png')` for a still of the latest frame
+* `viewer`, `client` the underlying `Viewer` and the ffmpeg process or TCP socket
 
 [example](https://github.com/PrismarineJS/prismarine-viewer/blob/master/examples/headless.js)
 

--- a/examples/headless.js
+++ b/examples/headless.js
@@ -8,8 +8,15 @@ const bot = mineflayer.createBot({
   username: 'Bot'
 })
 
-bot.once('spawn', () => {
-  // Record 200 frames, 512x512 pixels, and save them to output.mp4
-  mineflayerViewer(bot, { output: 'output.mp4', frames: 200, width: 512, height: 512 })
+bot.once('spawn', async () => {
+  // Record 10 seconds at 512x512, 20 fps, to output.mp4
+  const recording = mineflayerViewer(bot, { output: 'output.mp4', width: 512, height: 512, fps: 20 })
+  if (!recording) throw Error(`no assets for ${bot.version}`)
+  await recording.ready
   bot.setControlState('jump', true)
+  setTimeout(async () => {
+    await recording.stop()
+    console.log('saved output.mp4')
+    bot.quit()
+  }, 10000)
 })

--- a/lib/headless.js
+++ b/lib/headless.js
@@ -10,14 +10,24 @@ const net = require('net')
 const THREE = require('three')
 const { createCanvas } = safeRequire('node-canvas-webgl/lib')
 
-const { WorldView, Viewer, getBufferFromStream, createNodeHost } = require('../viewer')
+const { WorldView, Viewer, createNodeHost } = require('../viewer')
 
-module.exports = (bot, { viewDistance = 6, output = 'output.mp4', frames = -1, width = 512, height = 512, logFFMPEG = false, jpegOptions, numWorkers }) => {
+module.exports = (bot, { viewDistance = 6, output = 'output.mp4', frames = -1, fps = 20, width = 512, height = 512, logFFMPEG = false, jpegOptions, numWorkers } = {}) => {
+  if (!createCanvas) throw new Error('headless needs node-canvas-webgl: npm install PrismarineJS/node-canvas-webgl')
   const canvas = createCanvas(width, height)
   const renderer = new THREE.WebGLRenderer({ canvas })
   const viewer = new Viewer(renderer, { host: createNodeHost(), numWorkers })
 
+  function disposeGl () {
+    viewer.dispose()
+    // three's dispose cancels an animation frame that never existed headless
+    try { renderer.dispose() } catch {}
+    const gl = canvas.__gl__
+    if (gl) gl.getExtension('STACKGL_destroy_context')?.destroy()
+  }
+
   if (!viewer.setVersion(bot.version)) {
+    disposeGl()
     return false
   }
   viewer.setFirstPersonCamera(bot.entity.position, bot.entity.yaw, bot.entity.pitch)
@@ -32,13 +42,13 @@ module.exports = (bot, { viewDistance = 6, output = 'output.mp4', frames = -1, w
     worldView.updatePosition(bot.entity.position)
   }
 
-  // Render loop streaming
+  // Output sink: ffmpeg for rtmp:// and .mp4, a raw length-prefixed JPEG stream over TCP otherwise
   const rtmpOutput = output.startsWith('rtmp://')
   const ffmpegOutput = output.endsWith('mp4')
   let client = null
+  let sink = null
 
   if (rtmpOutput) {
-    const fps = 20
     const gop = fps * 2
     const gopMin = fps
     const probesize = '42M'
@@ -46,90 +56,95 @@ module.exports = (bot, { viewDistance = 6, output = 'output.mp4', frames = -1, w
     const threads = 4
     const args = `-y -r ${fps} -probesize ${probesize} -i pipe:0 -f flv -ac 2 -ar 44100 -vcodec libx264 -g ${gop} -keyint_min ${gopMin} -b:v ${cbr} -minrate ${cbr} -maxrate ${cbr} -pix_fmt yuv420p -s 1280x720 -preset ultrafast -tune film -threads ${threads} -strict normal -bufsize ${cbr} ${output}`.split(' ')
     client = spawn('ffmpeg', args)
-    if (logFFMPEG) {
-      client.stdout.on('data', (data) => {
-        console.log(`stdout: ${data}`)
-      })
-
-      client.stderr.on('data', (data) => {
-        console.error(`stderr: ${data}`)
-      })
-    }
-    update()
   } else if (ffmpegOutput) {
-    client = spawn('ffmpeg', ['-y', '-i', 'pipe:0', output])
-    if (logFFMPEG) {
-      client.stdout.on('data', (data) => {
-        console.log(`stdout: ${data}`)
-      })
-
-      client.stderr.on('data', (data) => {
-        console.error(`stderr: ${data}`)
-      })
-    }
-    update()
+    // Frames arrive paced at fps, so the container gets the same rate and a player-friendly pixel format
+    client = spawn('ffmpeg', ['-y', '-loglevel', logFFMPEG ? 'info' : 'error', '-framerate', String(fps), '-i', 'pipe:0', '-pix_fmt', 'yuv420p', output])
   } else {
     const [host, port] = output.split(':')
     client = new net.Socket()
-    client.connect(parseInt(port, 10), host, () => {
-      update()
-    })
+    client.connect(parseInt(port, 10), host)
   }
 
-  // Force end of stream
-  bot.on('end', () => { frames = 0 })
+  if (rtmpOutput || ffmpegOutput) {
+    if (logFFMPEG) {
+      client.stdout.on('data', (data) => { console.log(`stdout: ${data}`) })
+      client.stderr.on('data', (data) => { console.error(`stderr: ${data}`) })
+    }
+    sink = client.stdin
+    sink.on('error', () => { stop() })
+    client.on('exit', () => { stop() })
+  } else {
+    sink = client
+    sink.on('error', () => { stop() })
+    sink.on('close', () => { stop() })
+  }
 
+  let stopped = false
+  let stopping = null
+  let timer = null
   let idx = 0
-  function update () {
+  let t0 = 0
+  const frameMs = 1000 / fps
+
+  function frame () {
+    if (stopped) return
     viewer.update()
     renderer.render(viewer.scene, viewer.camera)
-
-    const imageStream = canvas.createJPEGStream({
-      bufsize: 4096,
-      quality: 1,
-      progressive: false,
-      ...jpegOptions
-    })
-
+    const jpeg = canvas.toBuffer('image/jpeg', { quality: 1, progressive: false, ...jpegOptions })
+    if (!sink.writable) { stop(); return }
     if (rtmpOutput || ffmpegOutput) {
-      imageStream.on('data', (chunk) => {
-        if (client.stdin.writable) {
-          client.stdin.write(chunk)
-        } else {
-          console.log('Error: ffmpeg stdin closed!')
-        }
-      })
-      imageStream.on('end', () => {
-        idx++
-        if (idx < frames || frames < 0) {
-          setTimeout(update, 16)
-        } else {
-          console.log('done streaming')
-          client.stdin.end()
-        }
-      })
-      imageStream.on('error', () => { })
+      sink.write(jpeg)
     } else {
-      getBufferFromStream(imageStream).then((buffer) => {
-        const sizebuff = new Uint8Array(4)
-        const view = new DataView(sizebuff.buffer, 0)
-        view.setUint32(0, buffer.length, true)
-        client.write(sizebuff)
-        client.write(buffer)
-
-        idx++
-        if (idx < frames || frames < 0) {
-          setTimeout(update, 16)
-        } else {
-          client.end()
-        }
-      }).catch(() => {})
+      const size = Buffer.alloc(4)
+      size.writeUInt32LE(jpeg.length, 0)
+      sink.write(size)
+      sink.write(jpeg)
     }
+    idx++
+    if (frames >= 0 && idx >= frames) { stop(); return }
+    // Wall-clock pacing: frame n goes out at t0 + n / fps however long rendering took
+    timer = setTimeout(frame, Math.max(0, t0 + idx * frameMs - Date.now()))
   }
+
+  // The first frame waits for the block atlas and the meshed sections around the bot,
+  // otherwise the recording opens on blank sky
+  const ready = (viewer.waitForReady ? viewer.waitForReady() : Promise.resolve()).then(() => {
+    if (stopped) return
+    t0 = Date.now()
+    frame()
+  })
+
+  // Closes the sink, waits for ffmpeg (which writes the mp4 index on stdin close) and frees the GL context
+  function stop () {
+    if (stopping) return stopping
+    stopped = true
+    stopping = (async () => {
+      clearTimeout(timer)
+      bot.off('move', botPosition)
+      bot.off('end', onEnd)
+      worldView.removeListenersFromBot(bot)
+      const closed = new Promise(resolve => {
+        if (rtmpOutput || ffmpegOutput) {
+          if (client.exitCode !== null || client.signalCode !== null) return resolve()
+          client.once('close', resolve)
+        } else {
+          if (client.destroyed) return resolve()
+          client.once('close', resolve)
+        }
+      })
+      if (sink.writable) sink.end()
+      await closed
+      disposeGl()
+    })()
+    return stopping
+  }
+
+  function onEnd () { stop() }
 
   // Register events
   bot.on('move', botPosition)
+  bot.on('end', onEnd)
   worldView.listenToBot(bot)
 
-  return client
+  return { client, canvas, viewer, worldView, ready, stop }
 }


### PR DESCRIPTION
Stacked on #503 (host-5-wait-for-ready); only the last commit is new.

`headless()` returned the ffmpeg process and kept rendering on a 16 ms timer with no way to end a recording: closing stdin logged "ffmpeg stdin closed!" once per frame forever, the mp4 played at whatever speed the frames happened to render at (ffmpeg assumed 25 fps for the JPEG pipe), and the first frames were blank sky because nothing waited for the atlas or the meshed sections.

It now returns a handle, `{ client, canvas, viewer, worldView, ready, stop }`:
- frames are paced on the wall clock at `fps` (new option, default 20) and ffmpeg is given the same `-framerate`, plus `-pix_fmt yuv420p` so the mp4 plays everywhere
- the first frame waits for `viewer.waitForReady()` (#503); `ready` resolves when it went out
- `stop()` ends the sink, waits for ffmpeg to finish the file (the moov atom is written on stdin close), detaches from the bot and frees the GL context; it is also run when `frames` is reached, the bot ends, or the output goes away
- `canvas` gives a still of the latest frame (`canvas.toBuffer('image/png')`)

Frames go through `canvas.toBuffer('image/jpeg')` instead of a JPEG stream per frame; node-canvas-webgl syncs the GL pixels in `toBuffer` the same way.

`frames` now defaults to `-1` as the README already claimed (the code said `-1`, the README said `200`; README updated to describe the handle). The example records ten seconds and stops.

Tested on a local vanilla 26.1 server through the merged 26.1 + host branch used by bot-harness: 640x360 at 20 fps, `ready` after the atlas and sections, `stop()` returns in under 200 ms with a playable file (`ffprobe`: 20/1, yuv420p).