### PR TITLE
Report an entity type with no model once instead of once per entity

### DIFF
--- a/viewer/lib/entities.js
+++ b/viewer/lib/entities.js
@@ -6,6 +6,8 @@ const { dispose3 } = require('./dispose')
 
 const { createCanvas } = require('canvas')
 
+const reportedMissingModels = new Set()
+
 function getEntityMesh (entity, scene) {
   if (entity.name) {
     try {
@@ -39,7 +41,11 @@ function getEntityMesh (entity, scene) {
 
       return e.mesh
     } catch (err) {
-      console.log(err)
+      // An entity type without a model is reported once and drawn as a box.
+      if (!reportedMissingModels.has(entity.name)) {
+        reportedMissingModels.add(entity.name)
+        console.log(err)
+      }
     }
   }
 

--- a/viewer/lib/entities.js
+++ b/viewer/lib/entities.js
@@ -41,10 +41,13 @@ function getEntityMesh (entity, scene) {
 
       return e.mesh
     } catch (err) {
-      // An entity type without a model is reported once and drawn as a box.
+      // An entity type without a model is reported once and drawn as a box. A server with a
+      // newer or modded entity list hits that on purpose, so it is one line; anything else
+      // thrown here is a real failure and keeps its stack.
       if (!reportedMissingModels.has(entity.name)) {
         reportedMissingModels.add(entity.name)
-        console.log(err)
+        if (err.message?.startsWith('Unknown entity')) console.warn(`prismarine-viewer: ${err.message}, drawing a box instead`)
+        else console.warn(err)
       }
     }
   }


### PR DESCRIPTION
Invariants of the missing-model fallback:

- An entity type prismarine-viewer has no model for is reported once per process.
- Every entity of that type still renders as the magenta box.
- Nothing else about the fallback changes.

The types that hit this on ordinary servers are `item`, `interaction`, `glow_item_frame` and `text_display`, and they spawn constantly: one recorded session logged the same four stacks 328 times, 271 of them for `item`.

No test: `getEntityMesh` is not exported, and the suite is jest with puppeteer against a rendered page, which cannot observe the log without a wrapper this change does not warrant.