### PR TITLE
Render dropped items

### DIFF
--- a/viewer/lib/entities.js
+++ b/viewer/lib/entities.js
@@ -2,11 +2,15 @@ const THREE = require('three')
 const TWEEN = require('@tweenjs/tween.js')
 
 const Entity = require('./entity/Entity')
+const { getItemMesh, animateItem } = require('./entity/Item')
 const { dispose3 } = require('./dispose')
 
 const { createCanvas } = require('canvas')
 
-function getEntityMesh (entity, scene) {
+function getEntityMesh (entity, scene, version) {
+  // A dropped item is its own item's model, and the stack only arrives after the spawn.
+  if (entity.itemName) return getItemMesh(entity.itemName, version)
+  if (entity.name === 'item') return null
   if (entity.name) {
     try {
       const e = new Entity('1.16.4', entity.name, scene)
@@ -98,6 +102,11 @@ class Entities {
     this.lastAnimate = performance.now()
   }
 
+  setVersion (version) {
+    this.version = version
+    this.clear()
+  }
+
   animate () {
     const now = performance.now()
     const ticks = (now - this.lastAnimate) / 50
@@ -105,6 +114,7 @@ class Entities {
     if (ticks === 0) return
     for (const mesh of Object.values(this.entities)) {
       if (mesh.walk) animateWalk(mesh, ticks)
+      if (mesh.item) animateItem(mesh, ticks)
     }
   }
 
@@ -117,10 +127,18 @@ class Entities {
   }
 
   update (entity) {
+    // A dropped item's stack arrives after its spawn and can change; its mesh is that stack's model.
+    const known = this.entities[entity.id]
+    if (known && entity.itemName !== undefined && known.itemName !== entity.itemName) {
+      this.scene.remove(known)
+      dispose3(known)
+      delete this.entities[entity.id]
+    }
     if (!this.entities[entity.id]) {
       if (!entity.pos) return
-      const mesh = getEntityMesh(entity, this.scene)
+      const mesh = getEntityMesh(entity, this.scene, this.version)
       if (!mesh) return
+      mesh.itemName = entity.itemName
       this.entities[entity.id] = mesh
       this.scene.add(mesh)
       if (entity.pos) mesh.position.set(entity.pos.x, entity.pos.y, entity.pos.z)

--- a/viewer/lib/entity/Item.js
+++ b/viewer/lib/entity/Item.js
@@ -1,0 +1,113 @@
+const THREE = require('three')
+const { loadTexture, loadPixels, loadJSON } = globalThis.isElectron ? require('../utils.electron.js') : require('../utils')
+
+// Ground display of the two item model parents: item/generated is the sprite at half scale extruded one
+// pixel deep, block/block is the block at quarter scale.
+const FLAT_SCALE = 0.5
+const FLAT_DEPTH = 1 / 16
+const BLOCK_SCALE = 0.25
+
+const indexes = {}
+
+function itemTextures (version) {
+  if (!indexes[version]) {
+    indexes[version] = new Promise(resolve => loadJSON(`textures/${version}/items_textures.json`, entries => {
+      const byName = {}
+      for (const entry of entries) byName[entry.name] = entry.texture
+      resolve(byName)
+    }))
+  }
+  return indexes[version]
+}
+
+// 'minecraft:block/white_wool' -> 'textures/26.1/blocks/white_wool.png'
+function texturePath (version, texture) {
+  return `textures/${version}/${texture.replace(/^minecraft:/, '').replace(/^block\//, 'blocks/')}.png`
+}
+
+// The sprite as the vanilla item model builder makes it: the picture on both faces and a rim of side
+// quads wherever an opaque texel borders a transparent one, so the silhouette has thickness.
+function spriteGeometry (pixels, size, depth) {
+  // An animated texture is a vertical strip of square frames; only the first is rendered.
+  const w = pixels.width
+  const h = pixels.height >= w && pixels.height % w === 0 ? w : pixels.height
+  const opaque = (x, y) => x >= 0 && y >= 0 && x < w && y < h && pixels.data[(y * pixels.width + x) * 4 + 3] > 0
+
+  const positions = []
+  const normals = []
+  const uvs = []
+  const px = x => (x / w - 0.5) * size
+  const py = y => (0.5 - y / h) * size
+  const pu = x => x / pixels.width
+  const pv = y => 1 - y / pixels.height
+  const quad = (corners, normal, uv) => {
+    for (const i of [0, 1, 2, 0, 2, 3]) {
+      positions.push(corners[i][0], corners[i][1], corners[i][2])
+      normals.push(normal[0], normal[1], normal[2])
+      uvs.push(uv[i][0], uv[i][1])
+    }
+  }
+
+  const d = depth / 2
+  const vb = pv(h); const vt = pv(0)
+  quad([[-size / 2, -size / 2, d], [size / 2, -size / 2, d], [size / 2, size / 2, d], [-size / 2, size / 2, d]],
+    [0, 0, 1], [[0, vb], [1, vb], [1, vt], [0, vt]])
+  quad([[size / 2, -size / 2, -d], [-size / 2, -size / 2, -d], [-size / 2, size / 2, -d], [size / 2, size / 2, -d]],
+    [0, 0, -1], [[1, vb], [0, vb], [0, vt], [1, vt]])
+
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      if (!opaque(x, y)) continue
+      const u0 = pu(x); const u1 = pu(x + 1); const v0 = pv(y + 1); const v1 = pv(y)
+      const uv = [[u0, v0], [u1, v0], [u1, v1], [u0, v1]]
+      if (!opaque(x - 1, y)) quad([[px(x), py(y + 1), -d], [px(x), py(y + 1), d], [px(x), py(y), d], [px(x), py(y), -d]], [-1, 0, 0], uv)
+      if (!opaque(x + 1, y)) quad([[px(x + 1), py(y + 1), d], [px(x + 1), py(y + 1), -d], [px(x + 1), py(y), -d], [px(x + 1), py(y), d]], [1, 0, 0], uv)
+      if (!opaque(x, y - 1)) quad([[px(x), py(y), d], [px(x + 1), py(y), d], [px(x + 1), py(y), -d], [px(x), py(y), -d]], [0, 1, 0], uv)
+      if (!opaque(x, y + 1)) quad([[px(x), py(y + 1), -d], [px(x + 1), py(y + 1), -d], [px(x + 1), py(y + 1), d], [px(x), py(y + 1), d]], [0, -1, 0], uv)
+    }
+  }
+
+  const geometry = new THREE.BufferGeometry()
+  geometry.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3))
+  geometry.setAttribute('normal', new THREE.Float32BufferAttribute(normals, 3))
+  geometry.setAttribute('uv', new THREE.Float32BufferAttribute(uvs, 2))
+  return geometry
+}
+
+/**
+ * A dropped item of `itemName`. The mesh stays empty until the version's texture index and the texture
+ * have loaded, and for an item the index has no texture for.
+ */
+function getItemMesh (itemName, version) {
+  const group = new THREE.Object3D()
+  const pivot = new THREE.Object3D()
+  group.add(pivot)
+  group.item = { pivot, size: 0, age: 0, bobOffset: Math.random() * Math.PI * 2 }
+
+  itemTextures(version).then(byName => {
+    const texture = byName[itemName]
+    if (!texture || !/^(minecraft:)?(items|block)\//.test(texture)) return
+    const isBlock = /^(minecraft:)?block\//.test(texture)
+    const size = isBlock ? BLOCK_SCALE : FLAT_SCALE
+    const path = texturePath(version, texture)
+    loadPixels(path, pixels => loadTexture(path, map => {
+      map.magFilter = THREE.NearestFilter
+      map.minFilter = THREE.NearestFilter
+      const geometry = isBlock ? new THREE.BoxGeometry(size, size, size) : spriteGeometry(pixels, size, size * FLAT_DEPTH)
+      pivot.add(new THREE.Mesh(geometry, new THREE.MeshLambertMaterial({ map, transparent: true, alphaTest: 0.1 })))
+      group.item.size = size
+    }))
+  })
+
+  return group
+}
+
+// Vanilla ItemEntityRenderer: bob sin(age / 10 + bobOffset) * 0.1 + 0.1, spin age / 20 + bobOffset radians.
+function animateItem (mesh, ticks) {
+  const item = mesh.item
+  item.age += ticks
+  item.pivot.position.y = item.size / 2 + 0.1 + Math.sin(item.age / 10 + item.bobOffset) * 0.1
+  item.pivot.rotation.y = item.age / 20 + item.bobOffset
+}
+
+module.exports = { getItemMesh, animateItem }

--- a/viewer/lib/utils.electron.js
+++ b/viewer/lib/utils.electron.js
@@ -1,3 +1,4 @@
+/* global document */
 const THREE = require('three')
 const path = require('path')
 
@@ -10,8 +11,23 @@ function loadTexture (texture, cb) {
   cb(textureCache[texture])
 }
 
+const pixelCache = {}
+function loadPixels (texture, cb) {
+  if (!pixelCache[texture]) {
+    const url = path.resolve(__dirname, '../../public/' + texture)
+    pixelCache[texture] = new Promise(resolve => new THREE.TextureLoader().load(url, ({ image }) => {
+      const canvas = document.createElement('canvas')
+      canvas.width = image.width
+      canvas.height = image.height
+      canvas.getContext('2d').drawImage(image, 0, 0)
+      resolve(canvas.getContext('2d').getImageData(0, 0, image.width, image.height))
+    }))
+  }
+  pixelCache[texture].then(cb)
+}
+
 function loadJSON (json, cb) {
   cb(require(path.resolve(__dirname, '../../public/' + json)))
 }
 
-module.exports = { loadTexture, loadJSON }
+module.exports = { loadTexture, loadPixels, loadJSON }

--- a/viewer/lib/utils.js
+++ b/viewer/lib/utils.js
@@ -6,6 +6,7 @@ function safeRequire (path) {
   }
 }
 const { loadImage } = safeRequire('node-canvas-webgl/lib')
+const { createCanvas } = safeRequire('canvas')
 const THREE = require('three')
 const path = require('path')
 
@@ -26,6 +27,25 @@ function loadTexture (texture, cb) {
   }
 }
 
+const pixelCache = {}
+// RGBA of a texture, for code that needs the picture itself and not just a map
+function loadPixels (texture, cb) {
+  if (process.platform === 'browser') {
+    return require('./utils.web').loadPixels(texture, cb)
+  }
+
+  if (pixelCache[texture]) {
+    cb(pixelCache[texture])
+  } else {
+    loadImage(path.resolve(__dirname, '../../public/' + texture)).then(image => {
+      const canvas = createCanvas(image.width, image.height)
+      canvas.getContext('2d').drawImage(image, 0, 0)
+      pixelCache[texture] = canvas.getContext('2d').getImageData(0, 0, image.width, image.height)
+      cb(pixelCache[texture])
+    })
+  }
+}
+
 function loadJSON (json, cb) {
   if (process.platform === 'browser') {
     return require('./utils.web').loadJSON(json, cb)
@@ -33,4 +53,4 @@ function loadJSON (json, cb) {
   cb(require(path.resolve(__dirname, '../../public/' + json)))
 }
 
-module.exports = { loadTexture, loadJSON }
+module.exports = { loadTexture, loadPixels, loadJSON }

--- a/viewer/lib/utils.web.js
+++ b/viewer/lib/utils.web.js
@@ -1,4 +1,4 @@
-/* global XMLHttpRequest */
+/* global XMLHttpRequest, document */
 const THREE = require('three')
 
 const textureCache = {}
@@ -7,6 +7,20 @@ function loadTexture (texture, cb) {
     textureCache[texture] = new Promise(resolve => new THREE.TextureLoader().load(texture, resolve))
   }
   textureCache[texture].then(cb)
+}
+
+const pixelCache = {}
+function loadPixels (texture, cb) {
+  if (!pixelCache[texture]) {
+    pixelCache[texture] = new Promise(resolve => new THREE.TextureLoader().load(texture, ({ image }) => {
+      const canvas = document.createElement('canvas')
+      canvas.width = image.width
+      canvas.height = image.height
+      canvas.getContext('2d').drawImage(image, 0, 0)
+      resolve(canvas.getContext('2d').getImageData(0, 0, image.width, image.height))
+    }))
+  }
+  pixelCache[texture].then(cb)
 }
 
 function loadJSON (url, callback) {
@@ -24,4 +38,4 @@ function loadJSON (url, callback) {
   xhr.send()
 }
 
-module.exports = { loadTexture, loadJSON }
+module.exports = { loadTexture, loadPixels, loadJSON }

--- a/viewer/lib/viewer.js
+++ b/viewer/lib/viewer.js
@@ -48,7 +48,7 @@ class Viewer {
     console.log(`Using version: ${version} (assets: ${assetsVersion})`)
     this.version = version
     this.world.setVersion(version, assetsVersion)
-    this.entities.clear()
+    this.entities.setVersion(assetsVersion)
     this.primitives.clear()
     return true
   }

--- a/viewer/lib/worldView.js
+++ b/viewer/lib/worldView.js
@@ -2,6 +2,20 @@ const { spiral, ViewRect, chunkPos } = require('./simpleUtils')
 const { Vec3 } = require('vec3')
 const EventEmitter = require('events')
 
+// A dropped item's stack lives in the entity's metadata, keyed by the raw metadata index.
+function droppedItemName (registry, entity) {
+  if (entity.name !== 'item' || !entity.metadata) return undefined
+  const keys = registry.entitiesByName?.item?.metadataKeys
+  const slots = keys ? [entity.metadata[keys.indexOf('item')]] : Object.values(entity.metadata)
+  for (const slot of slots) {
+    if (!slot || typeof slot !== 'object') continue
+    if (slot.present === false || slot.itemCount === 0) continue
+    const id = slot.itemId ?? slot.blockId
+    if (id === undefined || id < 0) continue
+    return registry.items[id]?.name
+  }
+}
+
 class WorldView extends EventEmitter {
   constructor (world, viewDistance, position = new Vec3(0, 0, 0), emitter = null) {
     super()
@@ -27,7 +41,11 @@ class WorldView extends EventEmitter {
       // 'move': botPosition,
       entitySpawn: function (e) {
         if (e === bot.entity) return
-        worldView.emitter.emit('entity', { id: e.id, name: e.name, pos: e.position, width: e.width, height: e.height, username: e.username, riding: !!e.vehicle })
+        worldView.emitter.emit('entity', { id: e.id, name: e.name, pos: e.position, width: e.width, height: e.height, username: e.username, riding: !!e.vehicle, itemName: droppedItemName(bot.registry, e) })
+      },
+      entityUpdate: function (e) {
+        const itemName = droppedItemName(bot.registry, e)
+        if (itemName !== undefined) worldView.emitter.emit('entity', { id: e.id, pos: e.position, itemName })
       },
       entityMoved: function (e) {
         worldView.emitter.emit('entity', { id: e.id, pos: e.position, pitch: e.pitch, yaw: e.yaw })
@@ -60,7 +78,7 @@ class WorldView extends EventEmitter {
     for (const id in bot.entities) {
       const e = bot.entities[id]
       if (e && e !== bot.entity) {
-        this.emitter.emit('entity', { id: e.id, name: e.name, pos: e.position, width: e.width, height: e.height, username: e.username, riding: !!e.vehicle })
+        this.emitter.emit('entity', { id: e.id, name: e.name, pos: e.position, width: e.width, height: e.height, username: e.username, riding: !!e.vehicle, itemName: droppedItemName(bot.registry, e) })
       }
     }
   }


### PR DESCRIPTION
A dropped item renders as its own item's model instead of the magenta missing-model box. `item` is by far the most common entity prismarine-viewer has no model for — one recorded session logged 271 of them.

Invariants:

- A dropped item is the sprite extruded along its alpha outline at half scale, or the block at quarter scale, matching the `ground` display of `item/generated` and `block/block`.
- It bobs and spins as `ItemEntityRenderer` does: `sin(age / 10 + bobOffset) * 0.1 + 0.1` and `age / 20 + bobOffset` radians.
- No mesh exists until the stack is known, and the mesh is rebuilt if the stack changes, so an item never shows as the box first.
- An item the version's texture index has no texture for keeps today's behaviour.

Where the pieces come from:

- The item name is the stack in the entity's metadata, resolved against `bot.registry` in `worldView` (the stack arrives in an `entityUpdate` after the spawn, so that event is now forwarded too).
- The texture is whatever `public/textures/<version>/items_textures.json` maps the item to — it already ships for every supported version and resolves block items to `block/<name>`, so no new assets are needed.
- Reading the sprite's alpha needs the picture and not just a map, so `loadPixels` joins `loadTexture` in the three `utils` backends.

Checked against a 26.1 server with iron_ingot, gold_ingot, emerald, diamond_sword, diamond_pickaxe, bow, cake, golden_apple, redstone_torch, tnt, oak_log and white_wool dropped in front of a headless bot: flat items show their extruded silhouette and go edge-on as they turn, block items are cubes at the smaller scale.

Known simplification: a block item is the one texture on all six faces, so `oak_log` shows its end grain all round rather than its side texture. Multi-texture block models would mean pulling the block model builder into the entity path.

No test: the suite is jest with puppeteer against a rendered page and has no entity-rendering coverage to extend.
