### PR TITLE
Decode host images without holding the event loop

### DIFF
--- a/test/host.test.js
+++ b/test/host.test.js
@@ -1,4 +1,5 @@
 /* eslint-env jest */
+const fs = require('fs')
 const path = require('path')
 const { createNodeHost } = require('../viewer/lib/host/node')
 const { loadTexture, loadPixels } = require('../viewer/lib/textures')
@@ -25,6 +26,27 @@ describe('node host', () => {
     expect(image.data).toBeInstanceOf(Uint8Array)
     expect(image.data.length).toBe(16 * 16 * 4)
     expect(image.data[3]).toBe(255)
+  })
+
+  it('decodes without holding the event loop', async () => {
+    const { PNG } = require('pngjs')
+    const atlas = createNodeHost()
+    const buffer = await fs.promises.readFile(path.join(__dirname, '../public/textures/1.16.4.png'))
+    const settle = () => new Promise(resolve => setTimeout(resolve, 10))
+    const longestBlock = async (work) => {
+      let longest = 0
+      let last = performance.now()
+      const timer = setInterval(() => { const now = performance.now(); longest = Math.max(longest, now - last - 2); last = now }, 2)
+      try {
+        await settle() // let the timer fire once so a block before the first tick still shows up
+        await work()
+        await settle()
+      } finally { clearInterval(timer) }
+      return longest
+    }
+    const blocking = await longestBlock(async () => PNG.sync.read(buffer))
+    const streamed = await longestBlock(async () => expect((await atlas.loadImage('textures/1.16.4.png')).width).toBe(1024))
+    expect(streamed).toBeLessThan(blocking / 2)
   })
 
   it('reads json assets', async () => {

--- a/viewer/lib/host/node.js
+++ b/viewer/lib/host/node.js
@@ -26,7 +26,12 @@ function createNodeHost ({ assetsDir = path.resolve(__dirname, '../../../public'
 
   return {
     async loadImage (name) {
-      const png = PNG.sync.read(await readAsset(name))
+      const buffer = await readAsset(name)
+      // The streaming parser yields between chunks; PNG.sync.read holds the event loop for the
+      // whole decode, which is 68 ms for a block atlas and stalls whatever else the process runs.
+      const png = await new Promise((resolve, reject) => {
+        new PNG().parse(buffer, (err, png) => err ? reject(err) : resolve(png))
+      })
       return { width: png.width, height: png.height, data: new Uint8Array(png.data.buffer, png.data.byteOffset, png.data.byteLength) }
     },
 


### PR DESCRIPTION
`createNodeHost().loadImage` decodes with `PNG.sync.read`, which holds the event loop for the whole decode. Measured here on the 1024x1024 block atlas: **68 ms blocking** for the synchronous read against **45 ms wall clock with a 6 ms worst-case block** for pngjs's streaming parser.

That matters because the host exists so another program can render in its own process. A mineflayer bot recording its first-person view loses one to two 50 ms physics ticks to that decode and then replays them back to back, which puts several movement packets in the same millisecond; the atlas is one decode, but every player skin and cape is another.

The new test measures the longest block during a decode and compares it with `PNG.sync.read` of the same buffer in the same process, so it does not depend on absolute timings: on `master` the streamed decode blocks as long as the synchronous one and the test fails.

Stacked on #490 like the rest of the host series.