### PR TITLE
Parse the block states in the mesher, not on the calling thread

### DIFF
--- a/test/host.test.js
+++ b/test/host.test.js
@@ -54,6 +54,12 @@ describe('node host', () => {
     expect(json.player.geometry).toBeDefined()
   })
 
+  it('reads an asset as text without parsing it', async () => {
+    const text = await host.loadText('entity/entities.json')
+    expect(typeof text).toBe('string')
+    expect(JSON.parse(text).player.geometry).toBeDefined()
+  })
+
   it('rejects a missing asset', async () => {
     await expect(host.loadImage('nope.png')).rejects.toThrow()
   })
@@ -109,6 +115,17 @@ describe('mesher', () => {
     expect(msg.key).toBe('0,0,0')
     expect(msg.geometry.positions.length).toBeGreaterThan(0)
     expect(transfer).toContain(msg.geometry.positions.buffer)
+  })
+
+  it('parses block states handed over as text', () => {
+    const posted = []
+    const mesher = createMesher((msg, transfer) => posted.push({ msg, transfer }))
+    mesher.handle({ type: 'version', version })
+    mesher.handle({ type: 'blockStates', text: JSON.stringify(blockStates()) })
+    mesher.handle({ type: 'chunk', x: 0, z: 0, chunk: stoneColumn() })
+    mesher.handle({ type: 'dirty', x: 0, y: 0, z: 0, value: true })
+    mesher.tick()
+    expect(posted.map(p => p.msg.type)).toContain('geometry')
   })
 
   it('runs inline behind the host worker interface', async () => {

--- a/test/host.test.js
+++ b/test/host.test.js
@@ -1,4 +1,5 @@
 /* eslint-env jest */
+const fs = require('fs')
 const path = require('path')
 const { createNodeHost } = require('../viewer/lib/host/node')
 const { loadTexture, loadPixels } = require('../viewer/lib/textures')
@@ -25,6 +26,27 @@ describe('node host', () => {
     expect(image.data).toBeInstanceOf(Uint8Array)
     expect(image.data.length).toBe(16 * 16 * 4)
     expect(image.data[3]).toBe(255)
+  })
+
+  it('decodes without holding the event loop', async () => {
+    const { PNG } = require('pngjs')
+    const atlas = createNodeHost()
+    const buffer = await fs.promises.readFile(path.join(__dirname, '../public/textures/1.16.4.png'))
+    const settle = () => new Promise(resolve => setTimeout(resolve, 10))
+    const longestBlock = async (work) => {
+      let longest = 0
+      let last = performance.now()
+      const timer = setInterval(() => { const now = performance.now(); longest = Math.max(longest, now - last - 2); last = now }, 2)
+      try {
+        await settle() // let the timer fire once so a block before the first tick still shows up
+        await work()
+        await settle()
+      } finally { clearInterval(timer) }
+      return longest
+    }
+    const blocking = await longestBlock(async () => PNG.sync.read(buffer))
+    const streamed = await longestBlock(async () => expect((await atlas.loadImage('textures/1.16.4.png')).width).toBe(1024))
+    expect(streamed).toBeLessThan(blocking / 2)
   })
 
   it('reads json assets', async () => {

--- a/viewer/README.md
+++ b/viewer/README.md
@@ -118,6 +118,7 @@ A host is everything the viewer needs from its platform. The rendering code only
 {
   loadImage (name),   // -> Promise<{ width, height, data }>: RGBA bytes, top row first
   loadJSON (name),    // -> Promise<object>
+  loadText (name),    // -> Promise<string>
   createWorker (),    // -> { postMessage (msg, transfer), onMessage (cb), terminate () }
   now (),             // -> milliseconds
   renderText (text)   // -> { width, height, data } or null; optional, draws username labels

--- a/viewer/lib/host/browser.js
+++ b/viewer/lib/host/browser.js
@@ -37,6 +37,13 @@ function createBrowserHost ({ assetsUrl = '', workerUrl = 'worker.js', texturePr
       return res.json()
     },
 
+    async loadText (name) {
+      const url = resolve(name)
+      const res = await fetch(url)
+      if (!res.ok) throw new Error(`${url}: ${res.status}`)
+      return res.text()
+    },
+
     createWorker () {
       const worker = new Worker(workerUrl)
       return {

--- a/viewer/lib/host/electron.js
+++ b/viewer/lib/host/electron.js
@@ -11,6 +11,7 @@ function createElectronHost ({ assetsDir, workerUrl = 'worker.js' } = {}) {
   return {
     loadImage: node.loadImage,
     loadJSON: node.loadJSON,
+    loadText: node.loadText,
     createWorker: browser.createWorker,
     now: browser.now,
     renderText: browser.renderText

--- a/viewer/lib/host/index.js
+++ b/viewer/lib/host/index.js
@@ -5,6 +5,7 @@
 //
 //   loadImage(name) -> Promise<{ width, height, data }>  RGBA bytes, top row first
 //   loadJSON(name) -> Promise<object>
+//   loadText(name) -> Promise<string>
 //   createWorker() -> { postMessage(msg, transfer), onMessage(cb), terminate() }
 //   now() -> milliseconds
 //   renderText(text) -> { width, height, data } | null   (optional: username sprites)

--- a/viewer/lib/host/node.js
+++ b/viewer/lib/host/node.js
@@ -17,6 +17,10 @@ function isUrl (name) {
 // drawn with node-canvas when it is installed. Nothing here needs a GL canvas,
 // so it pairs with headless-gl, node-canvas-webgl or any other renderer.
 function createNodeHost ({ assetsDir = path.resolve(__dirname, '../../../public'), fetch = globalThis.fetch, workerFile = path.join(__dirname, '../worker.node.js'), inlineMesher = false } = {}) {
+  async function readText (name) {
+    return (await readAsset(name)).toString('utf8')
+  }
+
   async function readAsset (name) {
     if (!isUrl(name)) return fs.promises.readFile(path.resolve(assetsDir, name))
     const res = await fetch(name)
@@ -36,8 +40,10 @@ function createNodeHost ({ assetsDir = path.resolve(__dirname, '../../../public'
     },
 
     async loadJSON (name) {
-      return JSON.parse((await readAsset(name)).toString('utf8'))
+      return JSON.parse(await readText(name))
     },
+
+    loadText: readText,
 
     createWorker () {
       if (inlineMesher) return createInlineWorker()

--- a/viewer/lib/host/node.js
+++ b/viewer/lib/host/node.js
@@ -26,7 +26,12 @@ function createNodeHost ({ assetsDir = path.resolve(__dirname, '../../../public'
 
   return {
     async loadImage (name) {
-      const png = PNG.sync.read(await readAsset(name))
+      const buffer = await readAsset(name)
+      // The streaming parser yields between chunks; PNG.sync.read holds the event loop for the
+      // whole decode, which is 68 ms for a block atlas and stalls whatever else the process runs.
+      const png = await new Promise((resolve, reject) => {
+        new PNG().parse(buffer, (err, png) => err ? reject(err) : resolve(png))
+      })
       return { width: png.width, height: png.height, data: new Uint8Array(png.data.buffer, png.data.byteOffset, png.data.byteLength) }
     },
 

--- a/viewer/lib/mesher.js
+++ b/viewer/lib/mesher.js
@@ -35,7 +35,7 @@ function createMesher (post) {
     if (data.type === 'version') {
       world = new World(data.version)
     } else if (data.type === 'blockStates') {
-      blocksStates = data.json
+      blocksStates = data.json ?? JSON.parse(data.text)
     } else if (data.type === 'dirty') {
       const loc = new Vec3(data.x, data.y, data.z)
       setSectionDirty(loc, data.value)

--- a/viewer/lib/worldrenderer.js
+++ b/viewer/lib/worldrenderer.js
@@ -111,12 +111,14 @@ class WorldRenderer {
       this.material.needsUpdate = true
     })
 
+    // Only the mesher reads the block states, and parsing them here would block for as long as
+    // the file is big (150 ms for 26.1), so the text goes to the workers unparsed.
     const blockStates = this.blockStatesData
-      ? Promise.resolve(this.blockStatesData)
-      : this.host.loadJSON(`blocksStates/${this.assetsVersion}.json`)
-    blockStates.then((json) => {
+      ? Promise.resolve({ json: this.blockStatesData })
+      : this.host.loadText(`blocksStates/${this.assetsVersion}.json`).then(text => ({ text }))
+    blockStates.then((message) => {
       for (const worker of this.workers) {
-        worker.postMessage({ type: 'blockStates', json })
+        worker.postMessage({ type: 'blockStates', ...message })
       }
     })
   }


### PR DESCRIPTION
Stacked on #507; its commit is the first one here, so review the second.

`WorldRenderer.updateTexturesData` parses `blocksStates/<version>.json` and then structured-clones the parsed object to every mesher worker, even though nothing on the calling thread reads it. For 26.1 that file is 13.4 MB and `JSON.parse` alone blocks for ~150 ms here.

That is three Minecraft ticks. For a bot rendering its own view in-process it is the largest single stall in bringing a viewer up: measured on a mineflayer bot starting a headless recorder, the worst event-loop block during startup drops from 171 ms to 27 ms with this change, leaving headless-gl's context creation as the longest one.

Hosts gain `loadText(name) -> Promise<string>`, and the mesher accepts `{ text }` next to `{ json }` so a caller-supplied `blockStatesData` still goes over parsed.