### PR TITLE
fix: resolve entity bone parents by name, whatever their case

### DIFF
--- a/viewer/lib/entity/Entity.js
+++ b/viewer/lib/entity/Entity.js
@@ -167,14 +167,18 @@ function getMesh (texture, jsonModel) {
     i++
   }
 
+  // Parent names are not cased like the bones they name (piglin parents leftItem to "leftArm"
+  // while the bone is "leftarm"), and a model can name a bone it does not define at all (witch's
+  // head): that bone stays at the model root rather than failing the whole entity.
+  const bonesByName = new Map(jsonModel.bones.map(jsonBone => [jsonBone.name.toLowerCase(), jsonBone]))
   const rootBones = []
   for (const jsonBone of jsonModel.bones) {
-    if (jsonBone.parent) {
-      const parentPivot = jsonModel.bones.find(b => b.name === jsonBone.parent).pivot
+    const parent = jsonBone.parent ? bonesByName.get(jsonBone.parent.toLowerCase()) : undefined
+    if (parent) {
       const bone = bones[jsonBone.name]
       // pivots are absolute in the json, bone positions are relative to the parent
-      if (parentPivot) bone.position.sub(new THREE.Vector3(...parentPivot))
-      bones[jsonBone.parent].add(bone)
+      if (parent.pivot) bone.position.sub(new THREE.Vector3(...parent.pivot))
+      bones[parent.name].add(bone)
     } else rootBones.push(bones[jsonBone.name])
   }
 


### PR DESCRIPTION
`getMesh` looked a bone's parent up with an exact name match, so a model that names its parent with different casing threw `Cannot read properties of undefined (reading 'pivot')`. `getEntityMesh` catches that and draws a magenta box, so **piglin, piglin_brute, pillager, vex, witch and zombified_piglin have never rendered their models**.

Five of the six are pure case mismatches in `entities.json` (piglin parents `leftItem` to `leftArm` while the bone is `leftarm`; pillager and vex do the same with `rightItem`), so matching case-insensitively links them to the right bone. The witch names a `head` its geometry does not define — its bones now stay at the model root instead of failing the whole entity.

Checked by building every entity in `entities.json`: 7 models threw before, 0 after, and the skeletons come out as expected (`piglin: … rightarm <- body, rightItem <- rightarm, leftarm <- body, leftItem <- leftarm …`).