### PR TITLE
Unload chunks the server unloads, and follow the world across a transfer

### DIFF
--- a/viewer/lib/worldView.js
+++ b/viewer/lib/worldView.js
@@ -47,6 +47,15 @@ class WorldView extends EventEmitter {
       chunkColumnLoad: function (pos) {
         worldView.loadChunk(pos)
       },
+      chunkColumnUnload: function (pos) {
+        worldView.unloadChunk(pos)
+      },
+      // A dimension change or server transfer unloads every column (each arrives above as a
+      // chunkColumnUnload) and may replace bot.world with a fresh object; follow it so chunks that
+      // load afterwards are read from the world the bot is now in, not the one it left.
+      login: function () {
+        worldView.world = bot.world
+      },
       blockUpdate: function (oldBlock, newBlock) {
         const stateId = newBlock.stateId ? newBlock.stateId : ((newBlock.type << 4) | newBlock.metadata)
         worldView.emitter.emit('blockUpdate', { pos: oldBlock.position, stateId })


### PR DESCRIPTION
### Problem

`WorldView.listenToBot` subscribes to `chunkColumnLoad` but not `chunkColumnUnload`, so a column the server unloads stays meshed in the viewer. It bites hardest on a world change: on a dimension change or a BungeeCord/Velocity server transfer, mineflayer's `switchWorld()` calls `unloadColumn` for **every** column of the bot's world. The viewer receives none of those, keeps all the old geometry, and — because those coordinates are still in `loadedChunks` — will not reliably remesh them for the world the bot moved into. A headless recorder that transferred mid-session kept rendering the world it had left.

### Change

Two listeners in `listenToBot`, both registered and removed by the existing loops:

- `chunkColumnUnload` → `unloadChunk(pos)`, mirroring the existing load path.
- `login` → `this.world = bot.world`, so if a transfer hands the bot a fresh world object, chunks that stream in afterwards are read from the current world rather than the one it left. (mineflayer usually mutates `bot.world` in place, in which case this is a no-op; it covers the paths that replace it.)

Scoped to the bot-driven path; the standalone/world-only usage is untouched. `standard` passes.
