### PR TITLE
Draw nothing for an invisible entity, like the vanilla client

### DIFF
--- a/viewer/lib/entities.js
+++ b/viewer/lib/entities.js
@@ -117,6 +117,17 @@ class Entities {
   }
 
   update (entity) {
+    // An invisible entity has no model in the vanilla client, so it gets no mesh here; one that
+    // was visible when it spawned loses the mesh it already has.
+    if (entity.invisible) {
+      const hidden = this.entities[entity.id]
+      if (hidden) {
+        this.scene.remove(hidden)
+        dispose3(hidden)
+        delete this.entities[entity.id]
+      }
+      return
+    }
     if (!this.entities[entity.id]) {
       if (!entity.pos) return
       const mesh = getEntityMesh(entity, this.scene)

--- a/viewer/lib/worldView.js
+++ b/viewer/lib/worldView.js
@@ -2,6 +2,16 @@ const { spiral, ViewRect, chunkPos } = require('./simpleUtils')
 const { Vec3 } = require('vec3')
 const EventEmitter = require('events')
 
+// Bit 0x20 of the shared entity flags, metadata index 0 on every version.
+const INVISIBLE_FLAG = 0x20
+
+// The vanilla client draws nothing for an invisible entity: LivingEntityRenderer.getRenderType
+// returns null once isBodyVisible is false and the entity is not glowing. Servers lean on that for
+// holograms, which are invisible marker armour stands carrying a name tag.
+function isInvisible (entity) {
+  return (((entity.metadata && entity.metadata[0]) || 0) & INVISIBLE_FLAG) !== 0
+}
+
 class WorldView extends EventEmitter {
   constructor (world, viewDistance, position = new Vec3(0, 0, 0), emitter = null) {
     super()
@@ -27,7 +37,13 @@ class WorldView extends EventEmitter {
       // 'move': botPosition,
       entitySpawn: function (e) {
         if (e === bot.entity) return
-        worldView.emitter.emit('entity', { id: e.id, name: e.name, pos: e.position, width: e.width, height: e.height, username: e.username, riding: !!e.vehicle })
+        worldView.emitter.emit('entity', { id: e.id, name: e.name, pos: e.position, width: e.width, height: e.height, username: e.username, riding: !!e.vehicle, invisible: isInvisible(e) })
+      },
+      entityUpdate: function (e) {
+        // The metadata that carries the invisible flag arrives after the spawn, and a mob can turn
+        // invisible at any time, so the flag is re-read on every metadata update.
+        if (e === bot.entity) return
+        worldView.emitter.emit('entity', { id: e.id, name: e.name, pos: e.position, width: e.width, height: e.height, username: e.username, riding: !!e.vehicle, invisible: isInvisible(e) })
       },
       entityMoved: function (e) {
         worldView.emitter.emit('entity', { id: e.id, pos: e.position, pitch: e.pitch, yaw: e.yaw })
@@ -60,7 +76,7 @@ class WorldView extends EventEmitter {
     for (const id in bot.entities) {
       const e = bot.entities[id]
       if (e && e !== bot.entity) {
-        this.emitter.emit('entity', { id: e.id, name: e.name, pos: e.position, width: e.width, height: e.height, username: e.username, riding: !!e.vehicle })
+        this.emitter.emit('entity', { id: e.id, name: e.name, pos: e.position, width: e.width, height: e.height, username: e.username, riding: !!e.vehicle, invisible: isInvisible(e) })
       }
     }
   }


### PR DESCRIPTION
## Problem

Every entity the bot can see gets a mesh, whatever its metadata says. Servers build holograms out of **invisible marker armour stands** carrying a name tag, and a hub or a minigame map has dozens of them — so the render fills with full-size armour stand models that no vanilla client ever draws. On a BedWars map they are most of what is in frame.

Before (Jartex BedWars island, `prismarine-viewer` recording a mineflayer bot):

- a forest of tan armour stand models floating over the islands, one per hologram line

## What vanilla does

`LivingEntityRenderer.submit` computes `isBodyVisible = !state.isInvisible` and calls `getRenderType`, which returns `null` when the body is not visible and the entity is not glowing:

```java
protected RenderType getRenderType(S state, boolean isBodyVisible, boolean forceTransparent, boolean appearGlowing) {
    Identifier texture = this.getTextureLocation(state);
    if (forceTransparent) return RenderTypes.entityTranslucentCullItemTarget(texture);
    else if (isBodyVisible) return this.model.renderType(texture);
    else return appearGlowing ? RenderTypes.outline(texture) : null;
}
```

`renderType == null` means no model is submitted at all.

## Fix

`worldView` reads bit `0x20` of the shared entity flags (metadata index 0, the same index on every version) and sends it along as `invisible`; `Entities.update` skips the mesh for an invisible entity and disposes the one it already has.

The flag arrives in a metadata packet *after* the spawn, and an entity can turn invisible at any time, so `entityUpdate` re-emits the entity — that listener is new here.

## Verified live

Same bot, same server (jartexnetwork_com.jartex.fun, 26.1), `record snapshot` before and after: the hub plaza, NPC podiums, trees and the hologram sign render with no armour stand models in the way, and holograms on the BedWars islands no longer block the view of the map.
